### PR TITLE
Fix header references and add nn::g3d::BindFuncTable

### DIFF
--- a/include/nn/account.h
+++ b/include/nn/account.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "os.h"
-#include "types.h"
+#include <nn/os.h>
+#include <nn/types.h>
 
 namespace nn {
 namespace account {

--- a/include/nn/atk/SoundArchivePlayer.h
+++ b/include/nn/atk/SoundArchivePlayer.h
@@ -5,11 +5,11 @@
 
 #pragma once
 
-#include "detail/AdvancedWaveSoundRuntime.h"
-#include "detail/SequenceSoundRuntime.h"
-#include "detail/SoundArchiveManager.h"
-#include "detail/StreamSoundRuntime.h"
-#include "detail/WaveSoundRuntime.h"
+#include <nn/atk/detail/AdvancedWaveSoundRuntime.h>
+#include <nn/atk/detail/SequenceSoundRuntime.h>
+#include <nn/atk/detail/SoundArchiveManager.h>
+#include <nn/atk/detail/StreamSoundRuntime.h>
+#include <nn/atk/detail/WaveSoundRuntime.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/SoundDataManager.h
+++ b/include/nn/atk/SoundDataManager.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/SoundPlayer.h
+++ b/include/nn/atk/SoundPlayer.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/detail/AdvancedWaveSoundRuntime.h
+++ b/include/nn/atk/detail/AdvancedWaveSoundRuntime.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/detail/BasicSound.h
+++ b/include/nn/atk/detail/BasicSound.h
@@ -5,8 +5,7 @@
 
 #pragma once
 
-#include "nn/atk/SoundPlayer.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/detail/SequenceSoundRuntime.h
+++ b/include/nn/atk/detail/SequenceSoundRuntime.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/detail/SoundArchiveManager.h
+++ b/include/nn/atk/detail/SoundArchiveManager.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/detail/StreamSoundRuntime.h
+++ b/include/nn/atk/detail/StreamSoundRuntime.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/atk/detail/WaveSoundRuntime.h
+++ b/include/nn/atk/detail/WaveSoundRuntime.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace atk {

--- a/include/nn/audio.h
+++ b/include/nn/audio.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace audio {

--- a/include/nn/bcat.h
+++ b/include/nn/bcat.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "os.h"
-#include "types.h"
+#include <nn/os.h>
+#include <nn/types.h>
 
 namespace nn {
 

--- a/include/nn/crypto.h
+++ b/include/nn/crypto.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace crypto {

--- a/include/nn/diag.h
+++ b/include/nn/diag.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace diag {
@@ -21,7 +21,7 @@ namespace detail {
 // LOG
 void LogImpl(nn::diag::LogMetaData const&, char const*, ...);
 void AbortImpl(char const*, char const*, char const*, s32);
-void AbortImpl(char const*, char const*, char const*, int, Result)
+void AbortImpl(char const*, char const*, char const*, int, Result);
 };  // namespace detail
 
 // MODULE / SYMBOL

--- a/include/nn/friends.h
+++ b/include/nn/friends.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "account.h"
-#include "os.h"
+#include <nn/account.h>
+#include <nn/os.h>
 
 namespace nn {
 namespace friends {

--- a/include/nn/fs.h
+++ b/include/nn/fs.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "account.h"
-#include "types.h"
+#include <nn/account.h>
+#include <nn/types.h>
 
 namespace nn {
 typedef u64 ApplicationId;

--- a/include/nn/g3d/BindFuncTable.h
+++ b/include/nn/g3d/BindFuncTable.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace g3d {
@@ -11,5 +11,21 @@ struct DDLDeclarations {
     u64 _10;
     u64 _18;
 };
+
+class BindFuncTable {
+    struct StringLength {
+        size_t length;
+        const char* content;
+    };
+    struct EntryPointer {
+        void* something_0;
+        nn::g3d::BindFuncTable::StringLength* string;
+    };
+
+private:
+    int lengths[4];
+    nn::g3d::BindFuncTable::EntryPointer strings[4];
+};
+
 };  // namespace g3d
 };  // namespace nn

--- a/include/nn/g3d/ResFile.h
+++ b/include/nn/g3d/ResFile.h
@@ -5,19 +5,23 @@
 
 #pragma once
 
-#include "nn/gfx/api.h"
-#include "nn/gfx/device.h"
-#include "nn/gfx/memory.h"
-#include "nn/util.h"
-#include "types.h"
-
-#include "ResMaterialAnim.h"
-#include "ResModel.h"
-#include "ResSceneAnim.h"
-#include "ResShapeAnim.h"
+#include <nn/gfx/api.h>
+#include <nn/gfx/memory.h>
+#include <nn/types.h>
+#include <nn/util.h>
 
 namespace nn {
+
+namespace gfx {
+template <typename T>
+class TDevice;
+}
+
 namespace g3d {
+class ResModel;
+class ResMaterialAnim;
+class ResShapeAnim;
+class ResSceneAnim;
 typedef void* TextureRef;
 
 class ResFile : public nn::util::BinaryFileHeader {

--- a/include/nn/g3d/ResFogAnim.h
+++ b/include/nn/g3d/ResFogAnim.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace g3d {

--- a/include/nn/g3d/ResLightAnim.h
+++ b/include/nn/g3d/ResLightAnim.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "BindFuncTable.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace g3d {

--- a/include/nn/g3d/ResMaterial.h
+++ b/include/nn/g3d/ResMaterial.h
@@ -5,9 +5,7 @@
 
 #pragma once
 
-#include "nn/gfx/api.h"
-#include "nn/gfx/device.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace g3d {

--- a/include/nn/g3d/ResModel.h
+++ b/include/nn/g3d/ResModel.h
@@ -5,9 +5,7 @@
 
 #pragma once
 
-#include "nn/gfx/api.h"
-#include "nn/gfx/device.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace g3d {

--- a/include/nn/g3d/ResSceneAnim.h
+++ b/include/nn/g3d/ResSceneAnim.h
@@ -5,13 +5,14 @@
 
 #pragma once
 
-#include "BindFuncTable.h"
-#include "ResFogAnim.h"
-#include "ResLightAnim.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace g3d {
+class ResLightAnim;
+class ResFogAnim;
+struct BindFuncTable;
+
 class ResSceneAnim {
 public:
     s32 Bind(nn::g3d::BindFuncTable const&);

--- a/include/nn/gfx/buffer.h
+++ b/include/nn/gfx/buffer.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace gfx {

--- a/include/nn/gfx/detail/bufferimpl.h
+++ b/include/nn/gfx/detail/bufferimpl.h
@@ -5,14 +5,17 @@
 
 #pragma once
 
-#include "nn/gfx/api.h"
-#include "nn/gfx/buffer.h"
-
 namespace nn {
 namespace gfx {
 class GpuAddress;
+class BufferInfo;
 
 namespace detail {
+template <typename T>
+class MemoryPoolImpl;
+template <typename T>
+class DeviceImpl;
+
 template <typename T>
 class BufferImpl {
 public:

--- a/include/nn/gfx/detail/deviceimpl.h
+++ b/include/nn/gfx/detail/deviceimpl.h
@@ -5,10 +5,10 @@
 
 #pragma once
 
-#include "nn/gfx/device.h"
-
 namespace nn {
 namespace gfx {
+class DeviceInfo;
+
 namespace detail {
 template <typename T>
 class DeviceImpl {

--- a/include/nn/gfx/detail/pool.h
+++ b/include/nn/gfx/detail/pool.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "deviceimpl.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace gfx {
 struct MemoryPoolInfo;
+template <typename T>
+struct DeviceImpl;
 
 namespace detail {
 class MemoryPoolData {

--- a/include/nn/gfx/device.h
+++ b/include/nn/gfx/device.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace gfx {

--- a/include/nn/hid.h
+++ b/include/nn/hid.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "types.h"
-#include "util.h"
+#include <nn/types.h>
+#include <nn/util.h>
 
 namespace nn {
 namespace hid {

--- a/include/nn/image.h
+++ b/include/nn/image.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace image {

--- a/include/nn/init.h
+++ b/include/nn/init.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "mem.h"
-#include "types.h"
+#include <nn/mem.h>
+#include <nn/types.h>
 
 namespace nn {
 namespace init {

--- a/include/nn/mem.h
+++ b/include/nn/mem.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "os.h"
-#include "types.h"
+#include <nn/os.h>
+#include <nn/types.h>
 
 namespace nn {
 namespace mem {

--- a/include/nn/nex/RootObject.h
+++ b/include/nn/nex/RootObject.h
@@ -5,26 +5,26 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace nex {
 class RootObject {
 public:
-    enum TargetPool;
+    enum TargetPool {};
 
     virtual ~RootObject();
 
-    void* operator new(std::u64);
+    void* operator new(u64);
     void operator delete(void*);
-    void* operator new(std::u64, char const*, u32);
-    void* operator new[](std::u64);
-    void* operator new[](std::u64, char const*, u32);
+    void* operator new(u64, char const*, u32);
+    void* operator new[](u64);
+    void* operator new[](u64, char const*, u32);
     void operator delete[](void*);
     void operator delete(void*, char const*, u32);
     void operator delete[](void*, char const*, u32);
-    void* operator new(std::u64, nn::nex::RootObject::TargetPool);
-    void* operator new(std::u64, nn::nex::RootObject::TargetPool, char const*, u32);
+    void* operator new(u64, nn::nex::RootObject::TargetPool);
+    void* operator new(u64, nn::nex::RootObject::TargetPool, char const*, u32);
 };
 };  // namespace nex
 };  // namespace nn

--- a/include/nn/nex/auth.h
+++ b/include/nn/nex/auth.h
@@ -5,8 +5,7 @@
 
 #pragma once
 
-#include "ddl.h"
-#include "types.h"
+#include <nn/nex/ddl.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/buffer.h
+++ b/include/nn/nex/buffer.h
@@ -5,11 +5,11 @@
 
 #pragma once
 
-#include "string.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace nex {
+class String;
 // todo
 class Buffer {
 public:

--- a/include/nn/nex/cache.h
+++ b/include/nn/nex/cache.h
@@ -5,10 +5,11 @@
 
 #pragma once
 
-#include "string.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace nex {
+class String;
 class BasicCache;
 
 class CacheManager {

--- a/include/nn/nex/checksum.h
+++ b/include/nn/nex/checksum.h
@@ -5,12 +5,12 @@
 
 #pragma once
 
-#include "RootObject.h"
-#include "buffer.h"
-#include "types.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {
+class Buffer;
+
 class ChecksumAlgorithm : public nn::nex::RootObject {
 public:
     ChecksumAlgorithm();

--- a/include/nn/nex/client.h
+++ b/include/nn/nex/client.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "system.h"
+#include <nn/nex/system.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/data.h
+++ b/include/nn/nex/data.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "RootObject.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/ddl.h
+++ b/include/nn/nex/ddl.h
@@ -5,8 +5,7 @@
 
 #pragma once
 
-#include "RootObject.h"
-#include "types.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/dynamic.h
+++ b/include/nn/nex/dynamic.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "RootObject.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/encryption.h
+++ b/include/nn/nex/encryption.h
@@ -5,13 +5,13 @@
 
 #pragma once
 
-#include "RootObject.h"
-#include "buffer.h"
-#include "key.h"
-#include "sead/critical.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {
+class Buffer;
+class Key;
+
 class EncryptionAlgorithm : public nn::nex::RootObject {
 public:
     EncryptionAlgorithm(u32, u32);

--- a/include/nn/nex/hash.h
+++ b/include/nn/nex/hash.h
@@ -5,9 +5,8 @@
 
 #pragma once
 
-#include "RootObject.h"
-#include "nn/crypto.h"
-#include "types.h"
+#include <nn/crypto.h>
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/instance.h
+++ b/include/nn/nex/instance.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "RootObject.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/key.h
+++ b/include/nn/nex/key.h
@@ -5,11 +5,12 @@
 
 #pragma once
 
-#include "RootObject.h"
-#include "string.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {
+class String;
+
 class Key : public nn::nex::RootObject {
 public:
     Key();

--- a/include/nn/nex/plugin.h
+++ b/include/nn/nex/plugin.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "RootObject.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/pseudo.h
+++ b/include/nn/nex/pseudo.h
@@ -5,9 +5,8 @@
 
 #pragma once
 
-#include "RootObject.h"
-#include "instance.h"
-#include "types.h"
+#include <nn/nex/RootObject.h>
+#include <nn/nex/instance.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/reference.h
+++ b/include/nn/nex/reference.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 
-#include "RootObject.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/socket.h
+++ b/include/nn/nex/socket.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <arpa/inet.h>
+#include <arpa/inet.h>  //FIXME requires proper musl-setup
 #include <sys/socket.h>
 #include "RootObject.h"
-#include "types.h"
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/string.h
+++ b/include/nn/nex/string.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "RootObject.h"
+#include <nn/nex/RootObject.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nex/system.h
+++ b/include/nn/nex/system.h
@@ -5,11 +5,12 @@
 
 #pragma once
 
-#include "reference.h"
-#include "string.h"
+#include <nn/nex/reference.h>
 
 namespace nn {
 namespace nex {
+class String;
+
 class SystemComponent : public nn::nex::RefCountedObject {
 public:
     enum _State {

--- a/include/nn/nex/time.h
+++ b/include/nn/nex/time.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace nex {

--- a/include/nn/nifm.h
+++ b/include/nn/nifm.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace nifm {

--- a/include/nn/nn.h
+++ b/include/nn/nn.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 typedef u64 ApplicationId;

--- a/include/nn/oe.h
+++ b/include/nn/oe.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "settings.h"
-#include "types.h"
+#include <nn/settings.h>
+#include <nn/types.h>
 
 namespace nn {
 namespace oe {

--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -7,8 +7,8 @@
 
 #include <type_traits>
 
-#include "time.h"
-#include "types.h"
+#include <nn/time.h>
+#include <nn/types.h>
 
 namespace nn {
 namespace os {

--- a/include/nn/prepo.h
+++ b/include/nn/prepo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn::account {
 class Uid;

--- a/include/nn/ro.h
+++ b/include/nn/ro.h
@@ -5,11 +5,16 @@
 
 #pragma once
 
-#include "ModuleObject.hpp"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace ro {
+
+namespace rtld {
+struct ModuleObject;  // TODO find this object and implement it. Original `#include` name:
+                      // ModuleObject.hpp, full path name: nn::ro::rtld::ModuleObject
+}
+
 class Module {
 public:
     rtld::ModuleObject* ModuleObject;
@@ -103,7 +108,7 @@ Result UnloadModule(Module*);
 Result GetBufferSize(size_t*, const void*);
 
 Result RegisterModuleInfo(RegistrationInfo*, void const*);
-Result RegisterModuleInfo(RegistrationInfo*, void const*, uint);
+Result RegisterModuleInfo(RegistrationInfo*, void const*, u32);
 Result UnregisterModuleInfo(RegistrationInfo*, void const*);
 };  // namespace ro
 

--- a/include/nn/socket.h
+++ b/include/nn/socket.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
+#include <nn/types.h>
 #include <sys/socket.h>
-#include "types.h"
 
 namespace nn {
 namespace socket {

--- a/include/nn/ssl.h
+++ b/include/nn/ssl.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace ssl {

--- a/include/nn/time.h
+++ b/include/nn/time.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 class TimeSpan {

--- a/include/nn/ui2d/Layout.h
+++ b/include/nn/ui2d/Layout.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace ui2d {

--- a/include/nn/ui2d/Material.h
+++ b/include/nn/ui2d/Material.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace ui2d {

--- a/include/nn/ui2d/Pane.h
+++ b/include/nn/ui2d/Pane.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "sead/runtime.h"
+#include "sead/runtime.h"  //FIXME this definitely is wrong
 #include "types.h"
 
 namespace nn {

--- a/include/nn/ui2d/Parts.h
+++ b/include/nn/ui2d/Parts.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "Pane.h"
+#include <nn/ui2d/Pane.h>
 
 namespace nn {
 namespace ui2d {

--- a/include/nn/ui2d/detail/TexCoordArray.h
+++ b/include/nn/ui2d/detail/TexCoordArray.h
@@ -5,10 +5,14 @@
 
 #pragma once
 
-#include "../util/Float2.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
+
+namespace util {
+struct Float2;
+}
+
 namespace ui2d {
 class Layout;
 

--- a/include/nn/util.h
+++ b/include/nn/util.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace util {

--- a/include/nn/util/Float2.h
+++ b/include/nn/util/Float2.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace util {

--- a/include/nn/vfx/Heap.h
+++ b/include/nn/vfx/Heap.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
 namespace vfx {

--- a/include/nn/vfx/System.h
+++ b/include/nn/vfx/System.h
@@ -5,12 +5,15 @@
 
 #pragma once
 
-#include "Config.h"
-#include "Heap.h"
+#include <nn/types.h>
+#include <nn/vfx/Config.h>
 
 // this class is massive
 namespace nn {
 namespace vfx {
+
+struct Heap;
+
 class System {
 public:
     System(nn::vfx::Config const&);

--- a/include/nn/vi.h
+++ b/include/nn/vi.h
@@ -5,10 +5,14 @@
 
 #pragma once
 
-#include "os.h"
-#include "types.h"
+#include <nn/types.h>
 
 namespace nn {
+
+namespace os {
+struct SystemEventType;
+}
+
 namespace vi {
 class Display;
 class Layer;
@@ -17,7 +21,7 @@ struct DisplayInfo {
     static const int maxNameLen = 64;
     char name[maxNameLen];
     bool hasLayerLimit;
-    __aligned(8) int64_t maxLayers;
+    int64_t maxLayers;
     int64_t maxWidth;
     int64_t maxHeight;
 };

--- a/include/nvn/nvn.h
+++ b/include/nvn/nvn.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nvn/nvn_types.h>
 #include <nvn/nvn_api.h>
+#include <nvn/nvn_types.h>
 
-NVNdummyProc nvnBootstrapLoader(const char *name);
+NVNdummyProc nvnBootstrapLoader(const char* name);

--- a/include/nvn/nvn_api.h
+++ b/include/nvn/nvn_api.h
@@ -5,488 +5,642 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
-#include <stddef.h>
 #include <nvn/nvn_types.h>
+#include <stddef.h>
+#include <stdint.h>
 
 // Function definitions
-typedef void (*nvnDeviceBuilderSetDefaultsFunction)(NVNdeviceBuilder *);
-typedef void (*nvnDeviceBuilderSetFlagsFunction)(NVNdeviceBuilder *, NVNdeviceFlagBits);
-typedef bool (*nvnDeviceInitializeFunction)(NVNdevice *, const NVNdeviceBuilder *);
-typedef void (*nvnDeviceFinalizeFunction)(NVNdevice *);
-typedef void (*nvnDeviceSetDebugLabelFunction)(NVNdevice *, const char *);
-typedef NVNdummyProc (*nvnDeviceGetProcAddressFunction)(const NVNdevice *, const char *);
-typedef void (*nvnDeviceGetIntegerFunction)(const NVNdevice *, NVNdeviceInfo, int *);
-typedef uint64_t (*nvnDeviceGetCurrentTimestampInNanosecondsFunction)(const NVNdevice *);
-typedef void (*nvnDeviceSetIntermediateShaderCacheFunction)(NVNdevice *, int);
-typedef NVNtextureHandle (*nvnDeviceGetTextureHandleFunction)(const NVNdevice *, int, int);
-typedef NVNtextureHandle (*nvnDeviceGetTexelFetchHandleFunction)(const NVNdevice *, int);
-typedef NVNimageHandle (*nvnDeviceGetImageHandleFunction)(const NVNdevice *, int);
-typedef void (*nvnDeviceInstallDebugCallbackFunction)(NVNdevice *, const NVNdebugCallback, void *, bool);
-typedef NVNdebugDomainId (*nvnDeviceGenerateDebugDomainIdFunction)(const NVNdevice *, const char *);
-typedef void (*nvnDeviceSetWindowOriginModeFunction)(NVNdevice *, NVNwindowOriginMode);
-typedef void (*nvnDeviceSetDepthModeFunction)(NVNdevice *, NVNdepthMode);
-typedef bool (*nvnDeviceRegisterFastClearColorFunction)(NVNdevice *, const float *, NVNformat);
-typedef bool (*nvnDeviceRegisterFastClearColoriFunction)(NVNdevice *, const int *, NVNformat);
-typedef bool (*nvnDeviceRegisterFastClearColoruiFunction)(NVNdevice *, const uint32_t *, NVNformat);
-typedef bool (*nvnDeviceRegisterFastClearDepthFunction)(NVNdevice *, float);
-typedef NVNwindowOriginMode (*nvnDeviceGetWindowOriginModeFunction)(const NVNdevice *);
-typedef NVNdepthMode (*nvnDeviceGetDepthModeFunction)(const NVNdevice *);
-typedef uint64_t (*nvnDeviceGetTimestampInNanosecondsFunction)(const NVNdevice *, const NVNcounterData *);
-typedef void (*nvnDeviceApplyDeferredFinalizesFunction)(NVNdevice *, int);
-typedef void (*nvnDeviceFinalizeCommandHandleFunction)(NVNdevice *, NVNcommandHandle);
-typedef void (*nvnDeviceWalkDebugDatabaseFunction)(const NVNdevice *, NVNdebugObjectType, NVNwalkDebugDatabaseCallback, void *);
-typedef NVNseparateTextureHandle (*nvnDeviceGetSeparateTextureHandleFunction)(const NVNdevice *, int);
-typedef NVNseparateSamplerHandle (*nvnDeviceGetSeparateSamplerHandleFunction)(const NVNdevice *, int);
-typedef bool (*nvnDeviceIsExternalDebuggerAttachedFunction)(const NVNdevice *);
-typedef NVNqueueGetErrorResult (*nvnQueueGetErrorFunction)(NVNqueue *, NVNqueueErrorInfo *);
-typedef size_t (*nvnQueueGetTotalCommandMemoryUsedFunction)(NVNqueue *);
-typedef size_t (*nvnQueueGetTotalControlMemoryUsedFunction)(NVNqueue *);
-typedef size_t (*nvnQueueGetTotalComputeMemoryUsedFunction)(NVNqueue *);
-typedef void (*nvnQueueResetMemoryUsageCountsFunction)(NVNqueue *);
-typedef void (*nvnQueueBuilderSetDeviceFunction)(NVNqueueBuilder *, NVNdevice *);
-typedef void (*nvnQueueBuilderSetDefaultsFunction)(NVNqueueBuilder *);
-typedef void (*nvnQueueBuilderSetFlagsFunction)(NVNqueueBuilder *, int);
-typedef void (*nvnQueueBuilderSetCommandMemorySizeFunction)(NVNqueueBuilder *, size_t);
-typedef void (*nvnQueueBuilderSetComputeMemorySizeFunction)(NVNqueueBuilder *, size_t);
-typedef void (*nvnQueueBuilderSetControlMemorySizeFunction)(NVNqueueBuilder *, size_t);
-typedef size_t (*nvnQueueBuilderGetQueueMemorySizeFunction)(const NVNqueueBuilder *);
-typedef void (*nvnQueueBuilderSetQueueMemoryFunction)(NVNqueueBuilder *, void *, size_t);
-typedef void (*nvnQueueBuilderSetCommandFlushThresholdFunction)(NVNqueueBuilder *, size_t);
-typedef bool (*nvnQueueInitializeFunction)(NVNqueue *, const NVNqueueBuilder *);
-typedef void (*nvnQueueFinalizeFunction)(NVNqueue *);
-typedef void (*nvnQueueSetDebugLabelFunction)(NVNqueue *, const char *);
-typedef void (*nvnQueueSubmitCommandsFunction)(NVNqueue *, int, const NVNcommandHandle *);
-typedef void (*nvnQueueFlushFunction)(NVNqueue *);
-typedef void (*nvnQueueFinishFunction)(NVNqueue *);
-typedef void (*nvnQueuePresentTextureFunction)(NVNqueue *, NVNwindow *, int);
-typedef NVNqueueAcquireTextureResult (*nvnQueueAcquireTextureFunction)(NVNqueue *, NVNwindow *, int *);
-typedef void (*nvnWindowBuilderSetDeviceFunction)(NVNwindowBuilder *, NVNdevice *);
-typedef void (*nvnWindowBuilderSetDefaultsFunction)(NVNwindowBuilder *);
-typedef void (*nvnWindowBuilderSetNativeWindowFunction)(NVNwindowBuilder *, NVNnativeWindow);
-typedef void (*nvnWindowBuilderSetTexturesFunction)(NVNwindowBuilder *, int, NVNtexture *const *);
-typedef void (*nvnWindowBuilderSetPresentIntervalFunction)(NVNwindowBuilder *, int);
-typedef NVNnativeWindow (*nvnWindowBuilderGetNativeWindowFunction)(const NVNwindowBuilder *);
-typedef int (*nvnWindowBuilderGetPresentIntervalFunction)(const NVNwindowBuilder *);
-typedef bool (*nvnWindowInitializeFunction)(NVNwindow *, const NVNwindowBuilder *);
-typedef void (*nvnWindowFinalizeFunction)(NVNwindow *);
-typedef void (*nvnWindowSetDebugLabelFunction)(NVNwindow *, const char *);
-typedef NVNwindowAcquireTextureResult (*nvnWindowAcquireTextureFunction)(NVNwindow *, NVNsync *, int *);
-typedef NVNnativeWindow (*nvnWindowGetNativeWindowFunction)(const NVNwindow *);
-typedef int (*nvnWindowGetPresentIntervalFunction)(const NVNwindow *);
-typedef void (*nvnWindowSetPresentIntervalFunction)(NVNwindow *, int);
-typedef void (*nvnWindowSetCropFunction)(NVNwindow *, int, int, int, int);
-typedef void (*nvnWindowGetCropFunction)(const NVNwindow *, NVNrectangle *);
-typedef bool (*nvnProgramInitializeFunction)(NVNprogram *, NVNdevice *);
-typedef void (*nvnProgramFinalizeFunction)(NVNprogram *);
-typedef void (*nvnProgramSetDebugLabelFunction)(NVNprogram *, const char *);
-typedef bool (*nvnProgramSetShadersFunction)(NVNprogram *, int, const NVNshaderData *);
-typedef void (*nvnMemoryPoolBuilderSetDeviceFunction)(NVNmemoryPoolBuilder *, NVNdevice *);
-typedef void (*nvnMemoryPoolBuilderSetDefaultsFunction)(NVNmemoryPoolBuilder *);
-typedef void (*nvnMemoryPoolBuilderSetStorageFunction)(NVNmemoryPoolBuilder *, void *, size_t);
-typedef void (*nvnMemoryPoolBuilderSetFlagsFunction)(NVNmemoryPoolBuilder *, int);
-typedef void (*nvnMemoryPoolBuilderGetMemoryFunction)(const NVNmemoryPoolBuilder *);
-typedef size_t (*nvnMemoryPoolBuilderGetSizeFunction)(const NVNmemoryPoolBuilder *);
-typedef NVNmemoryPoolFlags (*nvnMemoryPoolBuilderGetFlagsFunction)(const NVNmemoryPoolBuilder *);
-typedef bool (*nvnMemoryPoolInitializeFunction)(NVNmemoryPool *, const NVNmemoryPoolBuilder *);
-typedef void (*nvnMemoryPoolSetDebugLabelFunction)(NVNmemoryPool *, const char *);
-typedef void (*nvnMemoryPoolFinalizeFunction)(NVNmemoryPool *);
-typedef void (*nvnMemoryPoolMapFunction)(const NVNmemoryPool *);
-typedef void (*nvnMemoryPoolFlushMappedRangeFunction)(const NVNmemoryPool *, ptrdiff_t, size_t);
-typedef void (*nvnMemoryPoolInvalidateMappedRangeFunction)(const NVNmemoryPool *, ptrdiff_t, size_t);
-typedef NVNbufferAddress (*nvnMemoryPoolGetBufferAddressFunction)(const NVNmemoryPool *);
-typedef bool (*nvnMemoryPoolMapVirtualFunction)(NVNmemoryPool *, int, const NVNmappingRequest *);
-typedef size_t (*nvnMemoryPoolGetSizeFunction)(const NVNmemoryPool *);
-typedef NVNmemoryPoolFlags (*nvnMemoryPoolGetFlagsFunction)(const NVNmemoryPool *);
-typedef bool (*nvnTexturePoolInitializeFunction)(NVNtexturePool *, const NVNmemoryPool *, ptrdiff_t, int);
-typedef void (*nvnTexturePoolSetDebugLabelFunction)(NVNtexturePool *, const char *);
-typedef void (*nvnTexturePoolFinalizeFunction)(NVNtexturePool *);
-typedef void (*nvnTexturePoolRegisterTextureFunction)(const NVNtexturePool *, int, const NVNtexture *, const NVNtextureView *);
-typedef void (*nvnTexturePoolRegisterImageFunction)(const NVNtexturePool *, int, const NVNtexture *, const NVNtextureView *);
-typedef const NVNmemoryPool * (*nvnTexturePoolGetMemoryPoolFunction)(const NVNtexturePool *);
-typedef ptrdiff_t (*nvnTexturePoolGetMemoryOffsetFunction)(const NVNtexturePool *);
-typedef int (*nvnTexturePoolGetSizeFunction)(const NVNtexturePool *);
-typedef bool (*nvnSamplerPoolInitializeFunction)(NVNsamplerPool *, const NVNmemoryPool *, ptrdiff_t, int);
-typedef void (*nvnSamplerPoolSetDebugLabelFunction)(NVNsamplerPool *, const char *);
-typedef void (*nvnSamplerPoolFinalizeFunction)(NVNsamplerPool *);
-typedef void (*nvnSamplerPoolRegisterSamplerFunction)(const NVNsamplerPool *, int, const NVNsampler *);
-typedef void (*nvnSamplerPoolRegisterSamplerBuilderFunction)(const NVNsamplerPool *, int, const NVNsamplerBuilder *);
-typedef const NVNmemoryPool* (*nvnSamplerPoolGetMemoryPoolFunction)(const NVNsamplerPool *);
-typedef ptrdiff_t (*nvnSamplerPoolGetMemoryOffsetFunction)(const NVNsamplerPool *);
-typedef int (*nvnSamplerPoolGetSizeFunction)(const NVNsamplerPool *);
-typedef void (*nvnBufferBuilderSetDeviceFunction)(NVNbufferBuilder *, NVNdevice *);
-typedef void (*nvnBufferBuilderSetDefaultsFunction)(NVNbufferBuilder *);
-typedef void (*nvnBufferBuilderSetStorageFunction)(NVNbufferBuilder *, NVNmemoryPool *, ptrdiff_t, size_t);
-typedef NVNmemoryPool (*nvnBufferBuilderGetMemoryPoolFunction)(const NVNbufferBuilder *);
-typedef ptrdiff_t (*nvnBufferBuilderGetMemoryOffsetFunction)(const NVNbufferBuilder *);
-typedef size_t (*nvnBufferBuilderGetSizeFunction)(const NVNbufferBuilder *);
-typedef bool (*nvnBufferInitializeFunction)(NVNbuffer *, const NVNbufferBuilder *);
-typedef void (*nvnBufferSetDebugLabelFunction)(NVNbuffer *, const char *);
-typedef void (*nvnBufferFinalizeFunction)(NVNbuffer *);
-typedef void (*nvnBufferMapFunction)(const NVNbuffer *);
-typedef NVNbufferAddress (*nvnBufferGetAddressFunction)(const NVNbuffer *);
-typedef void (*nvnBufferFlushMappedRangeFunction)(const NVNbuffer *, ptrdiff_t, size_t);
-typedef void (*nvnBufferInvalidateMappedRangeFunction)(const NVNbuffer *, ptrdiff_t, size_t);
-typedef NVNmemoryPool (*nvnBufferGetMemoryPoolFunction)(const NVNbuffer *);
-typedef ptrdiff_t (*nvnBufferGetMemoryOffsetFunction)(const NVNbuffer *);
-typedef size_t (*nvnBufferGetSizeFunction)(const NVNbuffer *);
-typedef uint64_t (*nvnBufferGetDebugIDFunction)(const NVNbuffer *);
-typedef void (*nvnTextureBuilderSetDeviceFunction)(NVNtextureBuilder *, NVNdevice *);
-typedef void (*nvnTextureBuilderSetDefaultsFunction)(NVNtextureBuilder *);
-typedef void (*nvnTextureBuilderSetFlagsFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetTargetFunction)(NVNtextureBuilder *, NVNtextureTarget);
-typedef void (*nvnTextureBuilderSetWidthFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetHeightFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetDepthFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetSize1DFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetSize2DFunction)(NVNtextureBuilder *, int, int);
-typedef void (*nvnTextureBuilderSetSize3DFunction)(NVNtextureBuilder *, int, int, int);
-typedef void (*nvnTextureBuilderSetLevelsFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetFormatFunction)(NVNtextureBuilder *, NVNformat);
-typedef void (*nvnTextureBuilderSetSamplesFunction)(NVNtextureBuilder *, int);
-typedef void (*nvnTextureBuilderSetSwizzleFunction)(NVNtextureBuilder *, NVNtextureSwizzle, NVNtextureSwizzle, NVNtextureSwizzle, NVNtextureSwizzle);
-typedef void (*nvnTextureBuilderSetDepthStencilModeFunction)(NVNtextureBuilder *, NVNtextureDepthStencilMode);
-typedef size_t (*nvnTextureBuilderGetStorageSizeFunction)(const NVNtextureBuilder *);
-typedef size_t (*nvnTextureBuilderGetStorageAlignmentFunction)(const NVNtextureBuilder *);
-typedef void (*nvnTextureBuilderSetStorageFunction)(NVNtextureBuilder *, NVNmemoryPool *, ptrdiff_t);
-typedef void (*nvnTextureBuilderSetPackagedTextureDataFunction)(NVNtextureBuilder *, const void *);
-typedef void (*nvnTextureBuilderSetPackagedTextureLayoutFunction)(NVNtextureBuilder *, const NVNpackagedTextureLayout *);
-typedef void (*nvnTextureBuilderSetStrideFunction)(NVNtextureBuilder *, ptrdiff_t);
-typedef void (*nvnTextureBuilderSetGLTextureNameFunction)(NVNtextureBuilder *, uint32_t);
-typedef NVNstorageClass (*nvnTextureBuilderGetStorageClassFunction)(const NVNtextureBuilder *);
-typedef NVNtextureFlags (*nvnTextureBuilderGetFlagsFunction)(const NVNtextureBuilder *);
-typedef NVNtextureTarget (*nvnTextureBuilderGetTargetFunction)(const NVNtextureBuilder *);
-typedef int (*nvnTextureBuilderGetWidthFunction)(const NVNtextureBuilder *);
-typedef int (*nvnTextureBuilderGetHeightFunction)(const NVNtextureBuilder *);
-typedef int (*nvnTextureBuilderGetDepthFunction)(const NVNtextureBuilder *);
-typedef int (*nvnTextureBuilderGetLevelsFunction)(const NVNtextureBuilder *);
-typedef NVNformat (*nvnTextureBuilderGetFormatFunction)(const NVNtextureBuilder *);
-typedef int (*nvnTextureBuilderGetSamplesFunction)(const NVNtextureBuilder *);
-typedef void (*nvnTextureBuilderGetSwizzleFunction)(const NVNtextureBuilder *, NVNtextureSwizzle *, NVNtextureSwizzle *, NVNtextureSwizzle *, NVNtextureSwizzle *);
-typedef NVNtextureDepthStencilMode (*nvnTextureBuilderGetDepthStencilModeFunction)(const NVNtextureBuilder *);
-typedef const void * (*nvnTextureBuilderGetPackagedTextureDataFunction)(const NVNtextureBuilder *);
-typedef ptrdiff_t (*nvnTextureBuilderGetStrideFunction)(const NVNtextureBuilder *);
-typedef void (*nvnTextureBuilderGetSparseTileLayoutFunction)(const NVNtextureBuilder *, NVNtextureSparseTileLayout *);
-typedef uint32_t (*nvnTextureBuilderGetGLTextureNameFunction)(const NVNtextureBuilder *);
-typedef size_t (*nvnTextureBuilderGetZCullStorageSizeFunction)(const NVNtextureBuilder *);
-typedef NVNmemoryPool (*nvnTextureBuilderGetMemoryPoolFunction)(const NVNtextureBuilder *);
-typedef ptrdiff_t (*nvnTextureBuilderGetMemoryOffsetFunction)(const NVNtextureBuilder *);
-typedef void (*nvnTextureViewSetDefaultsFunction)(NVNtextureView *);
-typedef void (*nvnTextureViewSetLevelsFunction)(NVNtextureView *, int, int);
-typedef void (*nvnTextureViewSetLayersFunction)(NVNtextureView *, int, int);
-typedef void (*nvnTextureViewSetFormatFunction)(NVNtextureView *, NVNformat);
-typedef void (*nvnTextureViewSetSwizzleFunction)(NVNtextureView *, NVNtextureSwizzle, NVNtextureSwizzle, NVNtextureSwizzle, NVNtextureSwizzle);
-typedef void (*nvnTextureViewSetDepthStencilModeFunction)(NVNtextureView *, NVNtextureDepthStencilMode);
-typedef void (*nvnTextureViewSetTargetFunction)(NVNtextureView *, NVNtextureTarget);
-typedef bool (*nvnTextureViewGetLevelsFunction)(const NVNtextureView *, int *, int *);
-typedef bool (*nvnTextureViewGetLayersFunction)(const NVNtextureView *, int *, int *);
-typedef bool (*nvnTextureViewGetFormatFunction)(const NVNtextureView *, NVNformat *);
-typedef bool (*nvnTextureViewGetSwizzleFunction)(const NVNtextureView *, NVNtextureSwizzle *, NVNtextureSwizzle *, NVNtextureSwizzle *, NVNtextureSwizzle *);
-typedef bool (*nvnTextureViewGetDepthStencilModeFunction)(const NVNtextureView *, NVNtextureDepthStencilMode *);
-typedef bool (*nvnTextureViewGetTargetFunction)(const NVNtextureView *, NVNtextureTarget *);
-typedef bool (*nvnTextureViewCompareFunction)(const NVNtextureView *, const NVNtextureView *);
-typedef bool (*nvnTextureInitializeFunction)(NVNtexture *, const NVNtextureBuilder *);
-typedef size_t (*nvnTextureGetZCullStorageSizeFunction)(const NVNtexture *);
-typedef void (*nvnTextureFinalizeFunction)(NVNtexture *);
-typedef void (*nvnTextureSetDebugLabelFunction)(NVNtexture *, const char *);
-typedef NVNstorageClass (*nvnTextureGetStorageClassFunction)(const NVNtexture *);
-typedef ptrdiff_t (*nvnTextureGetViewOffsetFunction)(const NVNtexture *, const NVNtextureView *);
-typedef NVNtextureFlags (*nvnTextureGetFlagsFunction)(const NVNtexture *);
-typedef NVNtextureTarget (*nvnTextureGetTargetFunction)(const NVNtexture *);
-typedef int (*nvnTextureGetWidthFunction)(const NVNtexture *);
-typedef int (*nvnTextureGetHeightFunction)(const NVNtexture *);
-typedef int (*nvnTextureGetDepthFunction)(const NVNtexture *);
-typedef int (*nvnTextureGetLevelsFunction)(const NVNtexture *);
-typedef NVNformat (*nvnTextureGetFormatFunction)(const NVNtexture *);
-typedef int (*nvnTextureGetSamplesFunction)(const NVNtexture *);
-typedef void (*nvnTextureGetSwizzleFunction)(const NVNtexture *, NVNtextureSwizzle *, NVNtextureSwizzle *, NVNtextureSwizzle *, NVNtextureSwizzle *);
-typedef NVNtextureDepthStencilMode (*nvnTextureGetDepthStencilModeFunction)(const NVNtexture *);
-typedef ptrdiff_t (*nvnTextureGetStrideFunction)(const NVNtexture *);
-typedef NVNtextureAddress (*nvnTextureGetTextureAddressFunction)(const NVNtexture *);
-typedef void (*nvnTextureGetSparseTileLayoutFunction)(const NVNtexture *, NVNtextureSparseTileLayout *);
-typedef void (*nvnTextureWriteTexelsFunction)(const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, const void *);
-typedef void (*nvnTextureWriteTexelsStridedFunction)(const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, const void *, ptrdiff_t, ptrdiff_t);
-typedef void (*nvnTextureReadTexelsFunction)(const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, void *);
-typedef void (*nvnTextureReadTexelsStridedFunction)(const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, void *, ptrdiff_t, ptrdiff_t);
-typedef void (*nvnTextureFlushTexelsFunction)(const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *);
-typedef void (*nvnTextureInvalidateTexelsFunction)(const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *);
-typedef NVNmemoryPool (*nvnTextureGetMemoryPoolFunction)(const NVNtexture *);
-typedef ptrdiff_t (*nvnTextureGetMemoryOffsetFunction)(const NVNtexture *);
-typedef int (*nvnTextureGetStorageSizeFunction)(const NVNtexture *);
-typedef bool (*nvnTextureCompareFunction)(const NVNtexture *, const NVNtexture *);
-typedef uint64_t (*nvnTextureGetDebugIDFunction)(const NVNtexture *);
-typedef void (*nvnSamplerBuilderSetDeviceFunction)(NVNsamplerBuilder *, NVNdevice *);
-typedef void (*nvnSamplerBuilderSetDefaultsFunction)(NVNsamplerBuilder *);
-typedef void (*nvnSamplerBuilderSetMinMagFilterFunction)(NVNsamplerBuilder *, NVNminFilter, NVNmagFilter);
-typedef void (*nvnSamplerBuilderSetWrapModeFunction)(NVNsamplerBuilder *, NVNwrapMode, NVNwrapMode, NVNwrapMode);
-typedef void (*nvnSamplerBuilderSetLodClampFunction)(NVNsamplerBuilder *, float, float);
-typedef void (*nvnSamplerBuilderSetLodBiasFunction)(NVNsamplerBuilder *, float);
-typedef void (*nvnSamplerBuilderSetCompareFunction)(NVNsamplerBuilder *, NVNcompareMode, NVNcompareFunc);
-typedef void (*nvnSamplerBuilderSetBorderColorFunction)(NVNsamplerBuilder *, const float *);
-typedef void (*nvnSamplerBuilderSetBorderColoriFunction)(NVNsamplerBuilder *, const int *);
-typedef void (*nvnSamplerBuilderSetBorderColoruiFunction)(NVNsamplerBuilder *, const uint32_t *);
-typedef void (*nvnSamplerBuilderSetMaxAnisotropyFunction)(NVNsamplerBuilder *, float);
-typedef void (*nvnSamplerBuilderSetReductionFilterFunction)(NVNsamplerBuilder *, NVNsamplerReduction);
-typedef void (*nvnSamplerBuilderSetLodSnapFunction)(NVNsamplerBuilder *, float);
-typedef void (*nvnSamplerBuilderGetMinMagFilterFunction)(const NVNsamplerBuilder *, NVNminFilter *, NVNmagFilter *);
-typedef void (*nvnSamplerBuilderGetWrapModeFunction)(const NVNsamplerBuilder *, NVNwrapMode *, NVNwrapMode *, NVNwrapMode *);
-typedef void (*nvnSamplerBuilderGetLodClampFunction)(const NVNsamplerBuilder *, float *, float *);
-typedef float (*nvnSamplerBuilderGetLodBiasFunction)(const NVNsamplerBuilder *);
-typedef void (*nvnSamplerBuilderGetCompareFunction)(const NVNsamplerBuilder *, NVNcompareMode *, NVNcompareFunc *);
-typedef void (*nvnSamplerBuilderGetBorderColorFunction)(const NVNsamplerBuilder *, float *);
-typedef void (*nvnSamplerBuilderGetBorderColoriFunction)(const NVNsamplerBuilder *, int *);
-typedef void (*nvnSamplerBuilderGetBorderColoruiFunction)(const NVNsamplerBuilder *, uint32_t *);
-typedef float (*nvnSamplerBuilderGetMaxAnisotropyFunction)(const NVNsamplerBuilder *);
-typedef NVNsamplerReduction (*nvnSamplerBuilderGetReductionFilterFunction)(const NVNsamplerBuilder *);
-typedef float (*nvnSamplerBuilderGetLodSnapFunction)(const NVNsamplerBuilder *);
-typedef bool (*nvnSamplerInitializeFunction)(NVNsampler *, const NVNsamplerBuilder *);
-typedef void (*nvnSamplerFinalizeFunction)(NVNsampler *);
-typedef void (*nvnSamplerSetDebugLabelFunction)(NVNsampler *, const char *);
-typedef void (*nvnSamplerGetMinMagFilterFunction)(const NVNsampler *, NVNminFilter *, NVNmagFilter *);
-typedef void (*nvnSamplerGetWrapModeFunction)(const NVNsampler *, NVNwrapMode *, NVNwrapMode *, NVNwrapMode *);
-typedef void (*nvnSamplerGetLodClampFunction)(const NVNsampler *, float *, float *);
-typedef float (*nvnSamplerGetLodBiasFunction)(const NVNsampler *);
-typedef void (*nvnSamplerGetCompareFunction)(const NVNsampler *, NVNcompareMode *, NVNcompareFunc *);
-typedef void (*nvnSamplerGetBorderColorFunction)(const NVNsampler *, float *);
-typedef void (*nvnSamplerGetBorderColoriFunction)(const NVNsampler *, int *);
-typedef void (*nvnSamplerGetBorderColoruiFunction)(const NVNsampler *, uint32_t *);
-typedef float (*nvnSamplerGetMaxAnisotropyFunction)(const NVNsampler *);
-typedef NVNsamplerReduction (*nvnSamplerGetReductionFilterFunction)(const NVNsampler *);
-typedef bool (*nvnSamplerCompareFunction)(const NVNsampler *, const NVNsampler *);
-typedef uint64_t (*nvnSamplerGetDebugIDFunction)(const NVNsampler *);
-typedef void (*nvnBlendStateSetDefaultsFunction)(NVNblendState *);
-typedef void (*nvnBlendStateSetBlendTargetFunction)(NVNblendState *, int);
-typedef void (*nvnBlendStateSetBlendFuncFunction)(NVNblendState *, NVNblendFunc, NVNblendFunc, NVNblendFunc, NVNblendFunc);
-typedef void (*nvnBlendStateSetBlendEquationFunction)(NVNblendState *, NVNblendEquation, NVNblendEquation);
-typedef void (*nvnBlendStateSetAdvancedModeFunction)(NVNblendState *, NVNblendAdvancedMode);
-typedef void (*nvnBlendStateSetAdvancedOverlapFunction)(NVNblendState *, NVNblendAdvancedOverlap);
-typedef void (*nvnBlendStateSetAdvancedPremultipliedSrcFunction)(NVNblendState *, bool);
-typedef void (*nvnBlendStateSetAdvancedNormalizedDstFunction)(NVNblendState *, bool);
-typedef int (*nvnBlendStateGetBlendTargetFunction)(const NVNblendState *);
-typedef void (*nvnBlendStateGetBlendFuncFunction)(const NVNblendState *, NVNblendFunc *, NVNblendFunc *, NVNblendFunc *, NVNblendFunc *);
-typedef void (*nvnBlendStateGetBlendEquationFunction)(const NVNblendState *, NVNblendEquation *, NVNblendEquation *);
-typedef NVNblendAdvancedMode (*nvnBlendStateGetAdvancedModeFunction)(const NVNblendState *);
-typedef NVNblendAdvancedOverlap (*nvnBlendStateGetAdvancedOverlapFunction)(const NVNblendState *);
-typedef bool (*nvnBlendStateGetAdvancedPremultipliedSrcFunction)(const NVNblendState *);
-typedef bool (*nvnBlendStateGetAdvancedNormalizedDstFunction)(const NVNblendState *);
-typedef void (*nvnColorStateSetDefaultsFunction)(NVNcolorState *);
-typedef void (*nvnColorStateSetBlendEnableFunction)(NVNcolorState *, int, bool);
-typedef void (*nvnColorStateSetLogicOpFunction)(NVNcolorState *, NVNlogicOp);
-typedef void (*nvnColorStateSetAlphaTestFunction)(NVNcolorState *, NVNalphaFunc);
-typedef bool (*nvnColorStateGetBlendEnableFunction)(const NVNcolorState *, int);
-typedef NVNlogicOp (*nvnColorStateGetLogicOpFunction)(const NVNcolorState *);
-typedef NVNalphaFunc (*nvnColorStateGetAlphaTestFunction)(const NVNcolorState *);
-typedef void (*nvnChannelMaskStateSetDefaultsFunction)(NVNchannelMaskState *);
-typedef void (*nvnChannelMaskStateSetChannelMaskFunction)(NVNchannelMaskState *, int, bool, bool, bool, bool);
-typedef void (*nvnChannelMaskStateGetChannelMaskFunction)(const NVNchannelMaskState *, int, bool *, bool *, bool *, bool *);
-typedef void (*nvnMultisampleStateSetDefaultsFunction)(NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetMultisampleEnableFunction)(NVNmultisampleState *, bool);
-typedef void (*nvnMultisampleStateSetSamplesFunction)(NVNmultisampleState *, int);
-typedef void (*nvnMultisampleStateSetAlphaToCoverageEnableFunction)(NVNmultisampleState *, bool);
-typedef void (*nvnMultisampleStateSetAlphaToCoverageDitherFunction)(NVNmultisampleState *, bool);
-typedef bool (*nvnMultisampleStateGetMultisampleEnableFunction)(const NVNmultisampleState *);
-typedef int (*nvnMultisampleStateGetSamplesFunction)(const NVNmultisampleState *);
-typedef bool (*nvnMultisampleStateGetAlphaToCoverageEnableFunction)(const NVNmultisampleState *);
-typedef bool (*nvnMultisampleStateGetAlphaToCoverageDitherFunction)(const NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetRasterSamplesFunction)(NVNmultisampleState *, int);
-typedef int (*nvnMultisampleStateGetRasterSamplesFunction)(NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetCoverageModulationModeFunction)(NVNmultisampleState *, NVNcoverageModulationMode);
-typedef NVNcoverageModulationMode (*nvnMultisampleStateGetCoverageModulationModeFunction)(const NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetCoverageToColorEnableFunction)(NVNmultisampleState *, bool);
-typedef bool (*nvnMultisampleStateGetCoverageToColorEnableFunction)(const NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetCoverageToColorOutputFunction)(NVNmultisampleState *, int);
-typedef int (*nvnMultisampleStateGetCoverageToColorOutputFunction)(const NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetSampleLocationsEnableFunction)(NVNmultisampleState *, bool);
-typedef bool (*nvnMultisampleStateGetSampleLocationsEnableFunction)(const NVNmultisampleState *);
-typedef void (*nvnMultisampleStateGetSampleLocationsGridFunction)(NVNmultisampleState *, int *, int *);
-typedef void (*nvnMultisampleStateSetSampleLocationsGridEnableFunction)(NVNmultisampleState *, bool);
-typedef bool (*nvnMultisampleStateGetSampleLocationsGridEnableFunction)(const NVNmultisampleState *);
-typedef void (*nvnMultisampleStateSetSampleLocationsFunction)(NVNmultisampleState *, bool);
-typedef void (*nvnPolygonStateSetDefaultsFunction)(NVNpolygonState *);
-typedef void (*nvnPolygonStateSetCullFaceFunction)(NVNpolygonState *, NVNface);
-typedef void (*nvnPolygonStateSetFrontFaceFunction)(NVNpolygonState *, NVNfrontFace);
-typedef void (*nvnPolygonStateSetPolygonModeFunction)(NVNpolygonState *, NVNpolygonMode);
-typedef void (*nvnPolygonStateSetPolygonOffsetEnablesFunction)(NVNpolygonState *, int);
-typedef NVNface (*nvnPolygonStateGetCullFaceFunction)(const NVNpolygonState *);
-typedef NVNfrontFace (*nvnPolygonStateGetFrontFaceFunction)(const NVNpolygonState *);
-typedef NVNpolygonMode (*nvnPolygonStateGetPolygonModeFunction)(const NVNpolygonState *);
-typedef NVNpolygonOffsetEnable (*nvnPolygonStateGetPolygonOffsetEnablesFunction)(const NVNpolygonState *);
-typedef void (*nvnDepthStencilStateSetDefaultsFunction)(NVNdepthStencilState *);
-typedef void (*nvnDepthStencilStateSetDepthTestEnableFunction)(NVNdepthStencilState *, bool);
-typedef void (*nvnDepthStencilStateSetDepthWriteEnableFunction)(NVNdepthStencilState *, bool);
-typedef void (*nvnDepthStencilStateSetDepthFuncFunction)(NVNdepthStencilState *, NVNdepthFunc);
-typedef void (*nvnDepthStencilStateSetStencilTestEnableFunction)(NVNdepthStencilState *, bool);
-typedef void (*nvnDepthStencilStateSetStencilFuncFunction)(NVNdepthStencilState *, NVNface, NVNstencilFunc);
-typedef void (*nvnDepthStencilStateSetStencilOpFunction)(NVNdepthStencilState *, NVNface, NVNstencilOp, NVNstencilOp, NVNstencilOp);
-typedef bool (*nvnDepthStencilStateGetDepthTestEnableFunction)(const NVNdepthStencilState *);
-typedef bool (*nvnDepthStencilStateGetDepthWriteEnableFunction)(const NVNdepthStencilState *);
-typedef NVNdepthFunc (*nvnDepthStencilStateGetDepthFuncFunction)(const NVNdepthStencilState *);
-typedef bool (*nvnDepthStencilStateGetStencilTestEnableFunction)(const NVNdepthStencilState *);
-typedef NVNstencilFunc (*nvnDepthStencilStateGetStencilFuncFunction)(const NVNdepthStencilState *, NVNface);
-typedef void (*nvnDepthStencilStateGetStencilOpFunction)(const NVNdepthStencilState *, NVNface, NVNstencilOp *, NVNstencilOp *, NVNstencilOp *);
-typedef void (*nvnVertexAttribStateSetDefaultsFunction)(NVNvertexAttribState *);
-typedef void (*nvnVertexAttribStateSetFormatFunction)(NVNvertexAttribState *, NVNformat, ptrdiff_t);
-typedef void (*nvnVertexAttribStateSetStreamIndexFunction)(NVNvertexAttribState *, int);
-typedef void (*nvnVertexAttribStateGetFormatFunction)(const NVNvertexAttribState *, NVNformat *, ptrdiff_t *);
-typedef int (*nvnVertexAttribStateGetStreamIndexFunction)(const NVNvertexAttribState *);
-typedef void (*nvnVertexStreamStateSetDefaultsFunction)(NVNvertexStreamState *);
-typedef void (*nvnVertexStreamStateSetStrideFunction)(NVNvertexStreamState *, ptrdiff_t);
-typedef void (*nvnVertexStreamStateSetDivisorFunction)(NVNvertexStreamState *, int);
-typedef ptrdiff_t (*nvnVertexStreamStateGetStrideFunction)(const NVNvertexStreamState *);
-typedef int (*nvnVertexStreamStateGetDivisorFunction)(const NVNvertexStreamState *);
-typedef bool (*nvnCommandBufferInitializeFunction)(NVNcommandBuffer *, NVNdevice *);
-typedef void (*nvnCommandBufferFinalizeFunction)(NVNcommandBuffer *);
-typedef void (*nvnCommandBufferSetDebugLabelFunction)(NVNcommandBuffer *, const char *);
-typedef void (*nvnCommandBufferSetMemoryCallbackFunction)(NVNcommandBuffer *, NVNcommandBufferMemoryCallback);
-typedef void (*nvnCommandBufferSetMemoryCallbackDataFunction)(NVNcommandBuffer *, void *);
-typedef void (*nvnCommandBufferAddCommandMemoryFunction)(NVNcommandBuffer *, const NVNmemoryPool *, ptrdiff_t, size_t);
-typedef void (*nvnCommandBufferAddControlMemoryFunction)(NVNcommandBuffer *, void *, size_t);
-typedef size_t (*nvnCommandBufferGetCommandMemorySizeFunction)(const NVNcommandBuffer *);
-typedef size_t (*nvnCommandBufferGetCommandMemoryUsedFunction)(const NVNcommandBuffer *);
-typedef size_t (*nvnCommandBufferGetCommandMemoryFreeFunction)(const NVNcommandBuffer *);
-typedef size_t (*nvnCommandBufferGetControlMemorySizeFunction)(const NVNcommandBuffer *);
-typedef size_t (*nvnCommandBufferGetControlMemoryUsedFunction)(const NVNcommandBuffer *);
-typedef size_t (*nvnCommandBufferGetControlMemoryFreeFunction)(const NVNcommandBuffer *);
-typedef void (*nvnCommandBufferBeginRecordingFunction)(NVNcommandBuffer *);
-typedef NVNcommandHandle (*nvnCommandBufferEndRecordingFunction)(NVNcommandBuffer *);
-typedef void (*nvnCommandBufferCallCommandsFunction)(NVNcommandBuffer *, int, const NVNcommandHandle *);
-typedef void (*nvnCommandBufferCopyCommandsFunction)(NVNcommandBuffer *, int, const NVNcommandHandle *);
-typedef void (*nvnCommandBufferBindBlendStateFunction)(NVNcommandBuffer *, const NVNblendState *);
-typedef void (*nvnCommandBufferBindChannelMaskStateFunction)(NVNcommandBuffer *, const NVNchannelMaskState *);
-typedef void (*nvnCommandBufferBindColorStateFunction)(NVNcommandBuffer *, const NVNcolorState *);
-typedef void (*nvnCommandBufferBindMultisampleStateFunction)(NVNcommandBuffer *, const NVNmultisampleState *);
-typedef void (*nvnCommandBufferBindPolygonStateFunction)(NVNcommandBuffer *, const NVNpolygonState *);
-typedef void (*nvnCommandBufferBindDepthStencilStateFunction)(NVNcommandBuffer *, const NVNdepthStencilState *);
-typedef void (*nvnCommandBufferBindVertexAttribStateFunction)(NVNcommandBuffer *, int, const NVNvertexAttribState *);
-typedef void (*nvnCommandBufferBindVertexStreamStateFunction)(NVNcommandBuffer *, int, const NVNvertexStreamState *);
-typedef void (*nvnCommandBufferBindProgramFunction)(NVNcommandBuffer *, const NVNprogram *, int);
-typedef void (*nvnCommandBufferBindVertexBufferFunction)(NVNcommandBuffer *, int, NVNbufferAddress, size_t);
-typedef void (*nvnCommandBufferBindVertexBuffersFunction)(NVNcommandBuffer *, int, int, const NVNbufferRange *);
-typedef void (*nvnCommandBufferBindUniformBufferFunction)(NVNcommandBuffer *, NVNshaderStage, int, NVNbufferAddress, size_t);
-typedef void (*nvnCommandBufferBindUniformBuffersFunction)(NVNcommandBuffer *, NVNshaderStage, int, int, const NVNbufferRange *);
-typedef void (*nvnCommandBufferBindTransformFeedbackBufferFunction)(NVNcommandBuffer *, int, NVNbufferAddress, size_t);
-typedef void (*nvnCommandBufferBindTransformFeedbackBuffersFunction)(NVNcommandBuffer *, int, int, const NVNbufferRange *);
-typedef void (*nvnCommandBufferBindStorageBufferFunction)(NVNcommandBuffer *, NVNshaderStage, int, NVNbufferAddress, size_t);
-typedef void (*nvnCommandBufferBindStorageBuffersFunction)(NVNcommandBuffer *, NVNshaderStage, int, int, const NVNbufferRange *);
-typedef void (*nvnCommandBufferBindTextureFunction)(NVNcommandBuffer *, NVNshaderStage, int, NVNtextureHandle);
-typedef void (*nvnCommandBufferBindTexturesFunction)(NVNcommandBuffer *, NVNshaderStage, int, int, const NVNtextureHandle *);
-typedef void (*nvnCommandBufferBindImageFunction)(NVNcommandBuffer *, NVNshaderStage, int, NVNimageHandle);
-typedef void (*nvnCommandBufferBindImagesFunction)(NVNcommandBuffer *, NVNshaderStage, int, int, const NVNimageHandle *);
-typedef void (*nvnCommandBufferSetPatchSizeFunction)(NVNcommandBuffer *, int);
-typedef void (*nvnCommandBufferSetInnerTessellationLevelsFunction)(NVNcommandBuffer *, const float *);
-typedef void (*nvnCommandBufferSetOuterTessellationLevelsFunction)(NVNcommandBuffer *, const float *);
-typedef void (*nvnCommandBufferSetPrimitiveRestartFunction)(NVNcommandBuffer *, bool, int);
-typedef void (*nvnCommandBufferBeginTransformFeedbackFunction)(NVNcommandBuffer *, NVNbufferAddress);
-typedef void (*nvnCommandBufferEndTransformFeedbackFunction)(NVNcommandBuffer *, NVNbufferAddress);
-typedef void (*nvnCommandBufferPauseTransformFeedbackFunction)(NVNcommandBuffer *, NVNbufferAddress);
-typedef void (*nvnCommandBufferResumeTransformFeedbackFunction)(NVNcommandBuffer *, NVNbufferAddress);
-typedef void (*nvnCommandBufferDrawTransformFeedbackFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNbufferAddress);
-typedef void (*nvnCommandBufferDrawArraysFunction)(NVNcommandBuffer *, NVNdrawPrimitive, int, int);
-typedef void (*nvnCommandBufferDrawElementsFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNindexType, int, NVNbufferAddress);
-typedef void (*nvnCommandBufferDrawElementsBaseVertexFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNindexType, int, NVNbufferAddress, int);
-typedef void (*nvnCommandBufferDrawArraysInstancedFunction)(NVNcommandBuffer *, NVNdrawPrimitive, int, int, int, int);
-typedef void (*nvnCommandBufferDrawElementsInstancedFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNindexType, int, NVNbufferAddress, int, int, int);
-typedef void (*nvnCommandBufferDrawArraysIndirectFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNbufferAddress);
-typedef void (*nvnCommandBufferDrawElementsIndirectFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNindexType, NVNbufferAddress, NVNbufferAddress);
-typedef void (*nvnCommandBufferMultiDrawArraysIndirectCountFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNbufferAddress, NVNbufferAddress, int, ptrdiff_t);
-typedef void (*nvnCommandBufferMultiDrawElementsIndirectCountFunction)(NVNcommandBuffer *, NVNdrawPrimitive, NVNindexType, NVNbufferAddress, NVNbufferAddress, NVNbufferAddress, int, ptrdiff_t);
-typedef void (*nvnCommandBufferClearColorFunction)(NVNcommandBuffer *, int, const float *, int);
-typedef void (*nvnCommandBufferClearColoriFunction)(NVNcommandBuffer *, int, const int *, int);
-typedef void (*nvnCommandBufferClearColoruiFunction)(NVNcommandBuffer *, int, const uint32_t *, int);
-typedef void (*nvnCommandBufferClearDepthStencilFunction)(NVNcommandBuffer *, float, bool, int, int);
-typedef void (*nvnCommandBufferDispatchComputeFunction)(NVNcommandBuffer *, int, int, int);
-typedef void (*nvnCommandBufferDispatchComputeIndirectFunction)(NVNcommandBuffer *, NVNbufferAddress);
-typedef void (*nvnCommandBufferSetViewportFunction)(NVNcommandBuffer *, int, int, int, int);
-typedef void (*nvnCommandBufferSetViewportsFunction)(NVNcommandBuffer *, int, int, const float *);
-typedef void (*nvnCommandBufferSetViewportSwizzlesFunction)(NVNcommandBuffer *, int, int, const NVNviewportSwizzle *);
-typedef void (*nvnCommandBufferSetScissorFunction)(NVNcommandBuffer *, int, int, int, int);
-typedef void (*nvnCommandBufferSetScissorsFunction)(NVNcommandBuffer *, int, int, const int *);
-typedef void (*nvnCommandBufferSetDepthRangeFunction)(NVNcommandBuffer *, float, float);
-typedef void (*nvnCommandBufferSetDepthBoundsFunction)(NVNcommandBuffer *, bool, float, float);
-typedef void (*nvnCommandBufferSetDepthRangesFunction)(NVNcommandBuffer *, int, int, const float *);
-typedef void (*nvnCommandBufferSetTiledCacheActionFunction)(NVNcommandBuffer *, NVNtiledCacheAction);
-typedef void (*nvnCommandBufferSetTiledCacheTileSizeFunction)(NVNcommandBuffer *, int, int);
-typedef void (*nvnCommandBufferBindSeparateTextureFunction)(NVNcommandBuffer *, NVNshaderStage, int, NVNseparateTextureHandle);
-typedef void (*nvnCommandBufferBindSeparateSamplerFunction)(NVNcommandBuffer *, NVNshaderStage, int, NVNseparateSamplerHandle);
-typedef void (*nvnCommandBufferBindSeparateTexturesFunction)(NVNcommandBuffer *, NVNshaderStage, int, int, const NVNseparateTextureHandle *);
-typedef void (*nvnCommandBufferBindSeparateSamplersFunction)(NVNcommandBuffer *, NVNshaderStage, int, int, const NVNseparateSamplerHandle *);
-typedef void (*nvnCommandBufferSetStencilValueMaskFunction)(NVNcommandBuffer *, NVNface, int);
-typedef void (*nvnCommandBufferSetStencilMaskFunction)(NVNcommandBuffer *, NVNface, int);
-typedef void (*nvnCommandBufferSetStencilRefFunction)(NVNcommandBuffer *, NVNface, int);
-typedef void (*nvnCommandBufferSetBlendColorFunction)(NVNcommandBuffer *, const float *);
-typedef void (*nvnCommandBufferSetPointSizeFunction)(NVNcommandBuffer *, float);
-typedef void (*nvnCommandBufferSetLineWidthFunction)(NVNcommandBuffer *, float);
-typedef void (*nvnCommandBufferSetPolygonOffsetClampFunction)(NVNcommandBuffer *, float, float, float);
-typedef void (*nvnCommandBufferSetAlphaRefFunction)(NVNcommandBuffer *, float);
-typedef void (*nvnCommandBufferSetSampleMaskFunction)(NVNcommandBuffer *, int);
-typedef void (*nvnCommandBufferSetRasterizerDiscardFunction)(NVNcommandBuffer *, bool);
-typedef void (*nvnCommandBufferSetDepthClampFunction)(NVNcommandBuffer *, bool);
-typedef void (*nvnCommandBufferSetConservativeRasterEnableFunction)(NVNcommandBuffer *, bool);
-typedef void (*nvnCommandBufferSetConservativeRasterDilateFunction)(NVNcommandBuffer *, float);
-typedef void (*nvnCommandBufferSetSubpixelPrecisionBiasFunction)(NVNcommandBuffer *, int, int);
-typedef void (*nvnCommandBufferCopyBufferToTextureFunction)(NVNcommandBuffer *, NVNbufferAddress, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, int);
-typedef void (*nvnCommandBufferCopyTextureToBufferFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, NVNbufferAddress, int);
-typedef void (*nvnCommandBufferCopyTextureToTextureFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, int);
-typedef void (*nvnCommandBufferCopyBufferToBufferFunction)(NVNcommandBuffer *, NVNbufferAddress, NVNbufferAddress, size_t, int);
-typedef void (*nvnCommandBufferClearBufferFunction)(NVNcommandBuffer *, NVNbufferAddress, size_t, uint32_t);
-typedef void (*nvnCommandBufferClearTextureFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, const float *, int);
-typedef void (*nvnCommandBufferClearTextureiFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, const int *, int);
-typedef void (*nvnCommandBufferClearTextureuiFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNcopyRegion *, const uint32_t *, int);
-typedef void (*nvnCommandBufferUpdateUniformBufferFunction)(NVNcommandBuffer *, NVNbufferAddress, size_t, ptrdiff_t, size_t, const void *);
-typedef void (*nvnCommandBufferReportCounterFunction)(NVNcommandBuffer *, NVNcounterType, NVNbufferAddress);
-typedef void (*nvnCommandBufferResetCounterFunction)(NVNcommandBuffer *, NVNcounterType);
-typedef void (*nvnCommandBufferReportValueFunction)(NVNcommandBuffer *, uint32_t, NVNbufferAddress);
-typedef void (*nvnCommandBufferSetRenderEnableFunction)(NVNcommandBuffer *, bool);
-typedef void (*nvnCommandBufferSetRenderEnableConditionalFunction)(NVNcommandBuffer *, NVNconditionalRenderMode, NVNbufferAddress);
-typedef void (*nvnCommandBufferSetRenderTargetsFunction)(NVNcommandBuffer *, int, const NVNtexture *const *, const NVNtextureView *const *, const NVNtexture *, const NVNtextureView *);
-typedef void (*nvnCommandBufferDiscardColorFunction)(NVNcommandBuffer *, int);
-typedef void (*nvnCommandBufferDiscardDepthStencilFunction)(NVNcommandBuffer *);
-typedef void (*nvnCommandBufferDownsampleFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtexture *);
-typedef void (*nvnCommandBufferTiledDownsampleFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtexture *);
-typedef void (*nvnCommandBufferDownsampleTextureViewFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNtexture *, const NVNtextureView *);
-typedef void (*nvnCommandBufferTiledDownsampleTextureViewFunction)(NVNcommandBuffer *, const NVNtexture *, const NVNtextureView *, const NVNtexture *, const NVNtextureView *);
-typedef void (*nvnCommandBufferBarrierFunction)(NVNcommandBuffer *, int);
-typedef void (*nvnCommandBufferWaitSyncFunction)(NVNcommandBuffer *, const NVNsync *);
-typedef void (*nvnCommandBufferFenceSyncFunction)(NVNcommandBuffer *, NVNsync *, NVNsyncCondition, int);
-typedef void (*nvnCommandBufferSetTexturePoolFunction)(NVNcommandBuffer *, const NVNtexturePool *);
-typedef void (*nvnCommandBufferSetSamplerPoolFunction)(NVNcommandBuffer *, const NVNsamplerPool *);
-typedef void (*nvnCommandBufferSetShaderScratchMemoryFunction)(NVNcommandBuffer *, const NVNmemoryPool *, ptrdiff_t, size_t);
-typedef void (*nvnCommandBufferSaveZCullDataFunction)(NVNcommandBuffer *, NVNbufferAddress, size_t);
-typedef void (*nvnCommandBufferRestoreZCullDataFunction)(NVNcommandBuffer *, NVNbufferAddress, size_t);
-typedef void (*nvnCommandBufferSetCopyRowStrideFunction)(NVNcommandBuffer *, ptrdiff_t);
-typedef void (*nvnCommandBufferSetCopyImageStrideFunction)(NVNcommandBuffer *, ptrdiff_t);
-typedef ptrdiff_t (*nvnCommandBufferGetCopyRowStrideFunction)(const NVNcommandBuffer *);
-typedef ptrdiff_t (*nvnCommandBufferGetCopyImageStrideFunction)(const NVNcommandBuffer *);
-typedef void (*nvnCommandBufferDrawTextureFunction)(NVNcommandBuffer *, NVNtextureHandle, const NVNdrawTextureRegion *, const NVNdrawTextureRegion *);
-typedef bool (*nvnProgramSetSubroutineLinkageFunction)(NVNprogram *, int, const NVNsubroutineLinkageMapPtr *);
-typedef void (*nvnCommandBufferSetProgramSubroutinesFunction)(NVNcommandBuffer *, NVNprogram *, NVNshaderStage, const int, const int, const int *);
-typedef void (*nvnCommandBufferBindCoverageModulationTableFunction)(NVNcommandBuffer *, const float *);
-typedef void (*nvnCommandBufferResolveDepthBufferFunction)(NVNcommandBuffer *);
-typedef void (*nvnCommandBufferPushDebugGroupStaticFunction)(NVNcommandBuffer *, uint32_t, const char *);
-typedef void (*nvnCommandBufferPushDebugGroupDynamicFunction)(NVNcommandBuffer *, uint32_t, const char *);
-typedef void (*nvnCommandBufferPushDebugGroupFunction)(NVNcommandBuffer *, uint32_t, const char *);
-typedef void (*nvnCommandBufferPopDebugGroupFunction)(NVNcommandBuffer *);
-typedef void (*nvnCommandBufferPopDebugGroupIdFunction)(NVNcommandBuffer *, uint32_t);
-typedef void (*nvnCommandBufferInsertDebugMarkerStaticFunction)(NVNcommandBuffer *, uint32_t, const char *);
-typedef void (*nvnCommandBufferInsertDebugMarkerDynamicFunction)(NVNcommandBuffer *, uint32_t, const char *);
-typedef void (*nvnCommandBufferInsertDebugMarkerFunction)(NVNcommandBuffer *, uint32_t, const char *);
-typedef NVNcommandBufferMemoryCallback (*nvnCommandBufferGetMemoryCallbackFunction)(const NVNcommandBuffer *);
-typedef void (*nvnCommandBufferGetMemoryCallbackDataFunction)(const NVNcommandBuffer *);
-typedef bool (*nvnCommandBufferIsRecordingFunction)(const NVNcommandBuffer *);
-typedef bool (*nvnSyncInitializeFunction)(NVNsync *, NVNdevice *);
-typedef void (*nvnSyncFinalizeFunction)(NVNsync *);
-typedef void (*nvnSyncSetDebugLabelFunction)(NVNsync *, const char *);
-typedef void (*nvnQueueFenceSyncFunction)(NVNqueue *, NVNsync *, NVNsyncCondition, int);
-typedef NVNsyncWaitResult (*nvnSyncWaitFunction)(const NVNsync *, uint64_t);
-typedef bool (*nvnQueueWaitSyncFunction)(NVNqueue *, const NVNsync *);
-typedef void (*nvnEventBuilderSetDefaultsFunction)(NVNeventBuilder *);
-typedef void (*nvnEventBuilderSetStorageFunction)(NVNeventBuilder *, const NVNmemoryPool *, int64_t);
-typedef bool (*nvnEventInitializeFunction)(NVNevent *, const NVNeventBuilder *);
-typedef void (*nvnEventFinalizeFunction)(NVNevent *);
-typedef uint32_t (*nvnEventGetValueFunction)(const NVNevent *);
-typedef void (*nvnEventSignalFunction)(NVNevent *, NVNeventSignalMode, uint32_t);
-typedef void (*nvnCommandBufferWaitEventFunction)(NVNcommandBuffer *, const NVNevent *, NVNeventWaitMode, uint32_t);
-typedef void (*nvnCommandBufferSignalEventFunction)(NVNcommandBuffer *, const NVNevent *, NVNeventSignalMode, NVNeventSignalLocation, int, uint32_t);
+typedef void (*nvnDeviceBuilderSetDefaultsFunction)(NVNdeviceBuilder*);
+typedef void (*nvnDeviceBuilderSetFlagsFunction)(NVNdeviceBuilder*, NVNdeviceFlagBits);
+typedef bool (*nvnDeviceInitializeFunction)(NVNdevice*, const NVNdeviceBuilder*);
+typedef void (*nvnDeviceFinalizeFunction)(NVNdevice*);
+typedef void (*nvnDeviceSetDebugLabelFunction)(NVNdevice*, const char*);
+typedef NVNdummyProc (*nvnDeviceGetProcAddressFunction)(const NVNdevice*, const char*);
+typedef void (*nvnDeviceGetIntegerFunction)(const NVNdevice*, NVNdeviceInfo, int*);
+typedef uint64_t (*nvnDeviceGetCurrentTimestampInNanosecondsFunction)(const NVNdevice*);
+typedef void (*nvnDeviceSetIntermediateShaderCacheFunction)(NVNdevice*, int);
+typedef NVNtextureHandle (*nvnDeviceGetTextureHandleFunction)(const NVNdevice*, int, int);
+typedef NVNtextureHandle (*nvnDeviceGetTexelFetchHandleFunction)(const NVNdevice*, int);
+typedef NVNimageHandle (*nvnDeviceGetImageHandleFunction)(const NVNdevice*, int);
+typedef void (*nvnDeviceInstallDebugCallbackFunction)(NVNdevice*, const NVNdebugCallback, void*,
+                                                      bool);
+typedef NVNdebugDomainId (*nvnDeviceGenerateDebugDomainIdFunction)(const NVNdevice*, const char*);
+typedef void (*nvnDeviceSetWindowOriginModeFunction)(NVNdevice*, NVNwindowOriginMode);
+typedef void (*nvnDeviceSetDepthModeFunction)(NVNdevice*, NVNdepthMode);
+typedef bool (*nvnDeviceRegisterFastClearColorFunction)(NVNdevice*, const float*, NVNformat);
+typedef bool (*nvnDeviceRegisterFastClearColoriFunction)(NVNdevice*, const int*, NVNformat);
+typedef bool (*nvnDeviceRegisterFastClearColoruiFunction)(NVNdevice*, const uint32_t*, NVNformat);
+typedef bool (*nvnDeviceRegisterFastClearDepthFunction)(NVNdevice*, float);
+typedef NVNwindowOriginMode (*nvnDeviceGetWindowOriginModeFunction)(const NVNdevice*);
+typedef NVNdepthMode (*nvnDeviceGetDepthModeFunction)(const NVNdevice*);
+typedef uint64_t (*nvnDeviceGetTimestampInNanosecondsFunction)(const NVNdevice*,
+                                                               const NVNcounterData*);
+typedef void (*nvnDeviceApplyDeferredFinalizesFunction)(NVNdevice*, int);
+typedef void (*nvnDeviceFinalizeCommandHandleFunction)(NVNdevice*, NVNcommandHandle);
+typedef void (*nvnDeviceWalkDebugDatabaseFunction)(const NVNdevice*, NVNdebugObjectType,
+                                                   NVNwalkDebugDatabaseCallback, void*);
+typedef NVNseparateTextureHandle (*nvnDeviceGetSeparateTextureHandleFunction)(const NVNdevice*,
+                                                                              int);
+typedef NVNseparateSamplerHandle (*nvnDeviceGetSeparateSamplerHandleFunction)(const NVNdevice*,
+                                                                              int);
+typedef bool (*nvnDeviceIsExternalDebuggerAttachedFunction)(const NVNdevice*);
+typedef NVNqueueGetErrorResult (*nvnQueueGetErrorFunction)(NVNqueue*, NVNqueueErrorInfo*);
+typedef size_t (*nvnQueueGetTotalCommandMemoryUsedFunction)(NVNqueue*);
+typedef size_t (*nvnQueueGetTotalControlMemoryUsedFunction)(NVNqueue*);
+typedef size_t (*nvnQueueGetTotalComputeMemoryUsedFunction)(NVNqueue*);
+typedef void (*nvnQueueResetMemoryUsageCountsFunction)(NVNqueue*);
+typedef void (*nvnQueueBuilderSetDeviceFunction)(NVNqueueBuilder*, NVNdevice*);
+typedef void (*nvnQueueBuilderSetDefaultsFunction)(NVNqueueBuilder*);
+typedef void (*nvnQueueBuilderSetFlagsFunction)(NVNqueueBuilder*, int);
+typedef void (*nvnQueueBuilderSetCommandMemorySizeFunction)(NVNqueueBuilder*, size_t);
+typedef void (*nvnQueueBuilderSetComputeMemorySizeFunction)(NVNqueueBuilder*, size_t);
+typedef void (*nvnQueueBuilderSetControlMemorySizeFunction)(NVNqueueBuilder*, size_t);
+typedef size_t (*nvnQueueBuilderGetQueueMemorySizeFunction)(const NVNqueueBuilder*);
+typedef void (*nvnQueueBuilderSetQueueMemoryFunction)(NVNqueueBuilder*, void*, size_t);
+typedef void (*nvnQueueBuilderSetCommandFlushThresholdFunction)(NVNqueueBuilder*, size_t);
+typedef bool (*nvnQueueInitializeFunction)(NVNqueue*, const NVNqueueBuilder*);
+typedef void (*nvnQueueFinalizeFunction)(NVNqueue*);
+typedef void (*nvnQueueSetDebugLabelFunction)(NVNqueue*, const char*);
+typedef void (*nvnQueueSubmitCommandsFunction)(NVNqueue*, int, const NVNcommandHandle*);
+typedef void (*nvnQueueFlushFunction)(NVNqueue*);
+typedef void (*nvnQueueFinishFunction)(NVNqueue*);
+typedef void (*nvnQueuePresentTextureFunction)(NVNqueue*, NVNwindow*, int);
+typedef NVNqueueAcquireTextureResult (*nvnQueueAcquireTextureFunction)(NVNqueue*, NVNwindow*, int*);
+typedef void (*nvnWindowBuilderSetDeviceFunction)(NVNwindowBuilder*, NVNdevice*);
+typedef void (*nvnWindowBuilderSetDefaultsFunction)(NVNwindowBuilder*);
+typedef void (*nvnWindowBuilderSetNativeWindowFunction)(NVNwindowBuilder*, NVNnativeWindow);
+typedef void (*nvnWindowBuilderSetTexturesFunction)(NVNwindowBuilder*, int, NVNtexture* const*);
+typedef void (*nvnWindowBuilderSetPresentIntervalFunction)(NVNwindowBuilder*, int);
+typedef NVNnativeWindow (*nvnWindowBuilderGetNativeWindowFunction)(const NVNwindowBuilder*);
+typedef int (*nvnWindowBuilderGetPresentIntervalFunction)(const NVNwindowBuilder*);
+typedef bool (*nvnWindowInitializeFunction)(NVNwindow*, const NVNwindowBuilder*);
+typedef void (*nvnWindowFinalizeFunction)(NVNwindow*);
+typedef void (*nvnWindowSetDebugLabelFunction)(NVNwindow*, const char*);
+typedef NVNwindowAcquireTextureResult (*nvnWindowAcquireTextureFunction)(NVNwindow*, NVNsync*,
+                                                                         int*);
+typedef NVNnativeWindow (*nvnWindowGetNativeWindowFunction)(const NVNwindow*);
+typedef int (*nvnWindowGetPresentIntervalFunction)(const NVNwindow*);
+typedef void (*nvnWindowSetPresentIntervalFunction)(NVNwindow*, int);
+typedef void (*nvnWindowSetCropFunction)(NVNwindow*, int, int, int, int);
+typedef void (*nvnWindowGetCropFunction)(const NVNwindow*, NVNrectangle*);
+typedef bool (*nvnProgramInitializeFunction)(NVNprogram*, NVNdevice*);
+typedef void (*nvnProgramFinalizeFunction)(NVNprogram*);
+typedef void (*nvnProgramSetDebugLabelFunction)(NVNprogram*, const char*);
+typedef bool (*nvnProgramSetShadersFunction)(NVNprogram*, int, const NVNshaderData*);
+typedef void (*nvnMemoryPoolBuilderSetDeviceFunction)(NVNmemoryPoolBuilder*, NVNdevice*);
+typedef void (*nvnMemoryPoolBuilderSetDefaultsFunction)(NVNmemoryPoolBuilder*);
+typedef void (*nvnMemoryPoolBuilderSetStorageFunction)(NVNmemoryPoolBuilder*, void*, size_t);
+typedef void (*nvnMemoryPoolBuilderSetFlagsFunction)(NVNmemoryPoolBuilder*, int);
+typedef void (*nvnMemoryPoolBuilderGetMemoryFunction)(const NVNmemoryPoolBuilder*);
+typedef size_t (*nvnMemoryPoolBuilderGetSizeFunction)(const NVNmemoryPoolBuilder*);
+typedef NVNmemoryPoolFlags (*nvnMemoryPoolBuilderGetFlagsFunction)(const NVNmemoryPoolBuilder*);
+typedef bool (*nvnMemoryPoolInitializeFunction)(NVNmemoryPool*, const NVNmemoryPoolBuilder*);
+typedef void (*nvnMemoryPoolSetDebugLabelFunction)(NVNmemoryPool*, const char*);
+typedef void (*nvnMemoryPoolFinalizeFunction)(NVNmemoryPool*);
+typedef void (*nvnMemoryPoolMapFunction)(const NVNmemoryPool*);
+typedef void (*nvnMemoryPoolFlushMappedRangeFunction)(const NVNmemoryPool*, ptrdiff_t, size_t);
+typedef void (*nvnMemoryPoolInvalidateMappedRangeFunction)(const NVNmemoryPool*, ptrdiff_t, size_t);
+typedef NVNbufferAddress (*nvnMemoryPoolGetBufferAddressFunction)(const NVNmemoryPool*);
+typedef bool (*nvnMemoryPoolMapVirtualFunction)(NVNmemoryPool*, int, const NVNmappingRequest*);
+typedef size_t (*nvnMemoryPoolGetSizeFunction)(const NVNmemoryPool*);
+typedef NVNmemoryPoolFlags (*nvnMemoryPoolGetFlagsFunction)(const NVNmemoryPool*);
+typedef bool (*nvnTexturePoolInitializeFunction)(NVNtexturePool*, const NVNmemoryPool*, ptrdiff_t,
+                                                 int);
+typedef void (*nvnTexturePoolSetDebugLabelFunction)(NVNtexturePool*, const char*);
+typedef void (*nvnTexturePoolFinalizeFunction)(NVNtexturePool*);
+typedef void (*nvnTexturePoolRegisterTextureFunction)(const NVNtexturePool*, int, const NVNtexture*,
+                                                      const NVNtextureView*);
+typedef void (*nvnTexturePoolRegisterImageFunction)(const NVNtexturePool*, int, const NVNtexture*,
+                                                    const NVNtextureView*);
+typedef const NVNmemoryPool* (*nvnTexturePoolGetMemoryPoolFunction)(const NVNtexturePool*);
+typedef ptrdiff_t (*nvnTexturePoolGetMemoryOffsetFunction)(const NVNtexturePool*);
+typedef int (*nvnTexturePoolGetSizeFunction)(const NVNtexturePool*);
+typedef bool (*nvnSamplerPoolInitializeFunction)(NVNsamplerPool*, const NVNmemoryPool*, ptrdiff_t,
+                                                 int);
+typedef void (*nvnSamplerPoolSetDebugLabelFunction)(NVNsamplerPool*, const char*);
+typedef void (*nvnSamplerPoolFinalizeFunction)(NVNsamplerPool*);
+typedef void (*nvnSamplerPoolRegisterSamplerFunction)(const NVNsamplerPool*, int,
+                                                      const NVNsampler*);
+typedef void (*nvnSamplerPoolRegisterSamplerBuilderFunction)(const NVNsamplerPool*, int,
+                                                             const NVNsamplerBuilder*);
+typedef const NVNmemoryPool* (*nvnSamplerPoolGetMemoryPoolFunction)(const NVNsamplerPool*);
+typedef ptrdiff_t (*nvnSamplerPoolGetMemoryOffsetFunction)(const NVNsamplerPool*);
+typedef int (*nvnSamplerPoolGetSizeFunction)(const NVNsamplerPool*);
+typedef void (*nvnBufferBuilderSetDeviceFunction)(NVNbufferBuilder*, NVNdevice*);
+typedef void (*nvnBufferBuilderSetDefaultsFunction)(NVNbufferBuilder*);
+typedef void (*nvnBufferBuilderSetStorageFunction)(NVNbufferBuilder*, NVNmemoryPool*, ptrdiff_t,
+                                                   size_t);
+typedef NVNmemoryPool (*nvnBufferBuilderGetMemoryPoolFunction)(const NVNbufferBuilder*);
+typedef ptrdiff_t (*nvnBufferBuilderGetMemoryOffsetFunction)(const NVNbufferBuilder*);
+typedef size_t (*nvnBufferBuilderGetSizeFunction)(const NVNbufferBuilder*);
+typedef bool (*nvnBufferInitializeFunction)(NVNbuffer*, const NVNbufferBuilder*);
+typedef void (*nvnBufferSetDebugLabelFunction)(NVNbuffer*, const char*);
+typedef void (*nvnBufferFinalizeFunction)(NVNbuffer*);
+typedef void (*nvnBufferMapFunction)(const NVNbuffer*);
+typedef NVNbufferAddress (*nvnBufferGetAddressFunction)(const NVNbuffer*);
+typedef void (*nvnBufferFlushMappedRangeFunction)(const NVNbuffer*, ptrdiff_t, size_t);
+typedef void (*nvnBufferInvalidateMappedRangeFunction)(const NVNbuffer*, ptrdiff_t, size_t);
+typedef NVNmemoryPool (*nvnBufferGetMemoryPoolFunction)(const NVNbuffer*);
+typedef ptrdiff_t (*nvnBufferGetMemoryOffsetFunction)(const NVNbuffer*);
+typedef size_t (*nvnBufferGetSizeFunction)(const NVNbuffer*);
+typedef uint64_t (*nvnBufferGetDebugIDFunction)(const NVNbuffer*);
+typedef void (*nvnTextureBuilderSetDeviceFunction)(NVNtextureBuilder*, NVNdevice*);
+typedef void (*nvnTextureBuilderSetDefaultsFunction)(NVNtextureBuilder*);
+typedef void (*nvnTextureBuilderSetFlagsFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetTargetFunction)(NVNtextureBuilder*, NVNtextureTarget);
+typedef void (*nvnTextureBuilderSetWidthFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetHeightFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetDepthFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetSize1DFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetSize2DFunction)(NVNtextureBuilder*, int, int);
+typedef void (*nvnTextureBuilderSetSize3DFunction)(NVNtextureBuilder*, int, int, int);
+typedef void (*nvnTextureBuilderSetLevelsFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetFormatFunction)(NVNtextureBuilder*, NVNformat);
+typedef void (*nvnTextureBuilderSetSamplesFunction)(NVNtextureBuilder*, int);
+typedef void (*nvnTextureBuilderSetSwizzleFunction)(NVNtextureBuilder*, NVNtextureSwizzle,
+                                                    NVNtextureSwizzle, NVNtextureSwizzle,
+                                                    NVNtextureSwizzle);
+typedef void (*nvnTextureBuilderSetDepthStencilModeFunction)(NVNtextureBuilder*,
+                                                             NVNtextureDepthStencilMode);
+typedef size_t (*nvnTextureBuilderGetStorageSizeFunction)(const NVNtextureBuilder*);
+typedef size_t (*nvnTextureBuilderGetStorageAlignmentFunction)(const NVNtextureBuilder*);
+typedef void (*nvnTextureBuilderSetStorageFunction)(NVNtextureBuilder*, NVNmemoryPool*, ptrdiff_t);
+typedef void (*nvnTextureBuilderSetPackagedTextureDataFunction)(NVNtextureBuilder*, const void*);
+typedef void (*nvnTextureBuilderSetPackagedTextureLayoutFunction)(NVNtextureBuilder*,
+                                                                  const NVNpackagedTextureLayout*);
+typedef void (*nvnTextureBuilderSetStrideFunction)(NVNtextureBuilder*, ptrdiff_t);
+typedef void (*nvnTextureBuilderSetGLTextureNameFunction)(NVNtextureBuilder*, uint32_t);
+typedef NVNstorageClass (*nvnTextureBuilderGetStorageClassFunction)(const NVNtextureBuilder*);
+typedef NVNtextureFlags (*nvnTextureBuilderGetFlagsFunction)(const NVNtextureBuilder*);
+typedef NVNtextureTarget (*nvnTextureBuilderGetTargetFunction)(const NVNtextureBuilder*);
+typedef int (*nvnTextureBuilderGetWidthFunction)(const NVNtextureBuilder*);
+typedef int (*nvnTextureBuilderGetHeightFunction)(const NVNtextureBuilder*);
+typedef int (*nvnTextureBuilderGetDepthFunction)(const NVNtextureBuilder*);
+typedef int (*nvnTextureBuilderGetLevelsFunction)(const NVNtextureBuilder*);
+typedef NVNformat (*nvnTextureBuilderGetFormatFunction)(const NVNtextureBuilder*);
+typedef int (*nvnTextureBuilderGetSamplesFunction)(const NVNtextureBuilder*);
+typedef void (*nvnTextureBuilderGetSwizzleFunction)(const NVNtextureBuilder*, NVNtextureSwizzle*,
+                                                    NVNtextureSwizzle*, NVNtextureSwizzle*,
+                                                    NVNtextureSwizzle*);
+typedef NVNtextureDepthStencilMode (*nvnTextureBuilderGetDepthStencilModeFunction)(
+    const NVNtextureBuilder*);
+typedef const void* (*nvnTextureBuilderGetPackagedTextureDataFunction)(const NVNtextureBuilder*);
+typedef ptrdiff_t (*nvnTextureBuilderGetStrideFunction)(const NVNtextureBuilder*);
+typedef void (*nvnTextureBuilderGetSparseTileLayoutFunction)(const NVNtextureBuilder*,
+                                                             NVNtextureSparseTileLayout*);
+typedef uint32_t (*nvnTextureBuilderGetGLTextureNameFunction)(const NVNtextureBuilder*);
+typedef size_t (*nvnTextureBuilderGetZCullStorageSizeFunction)(const NVNtextureBuilder*);
+typedef NVNmemoryPool (*nvnTextureBuilderGetMemoryPoolFunction)(const NVNtextureBuilder*);
+typedef ptrdiff_t (*nvnTextureBuilderGetMemoryOffsetFunction)(const NVNtextureBuilder*);
+typedef void (*nvnTextureViewSetDefaultsFunction)(NVNtextureView*);
+typedef void (*nvnTextureViewSetLevelsFunction)(NVNtextureView*, int, int);
+typedef void (*nvnTextureViewSetLayersFunction)(NVNtextureView*, int, int);
+typedef void (*nvnTextureViewSetFormatFunction)(NVNtextureView*, NVNformat);
+typedef void (*nvnTextureViewSetSwizzleFunction)(NVNtextureView*, NVNtextureSwizzle,
+                                                 NVNtextureSwizzle, NVNtextureSwizzle,
+                                                 NVNtextureSwizzle);
+typedef void (*nvnTextureViewSetDepthStencilModeFunction)(NVNtextureView*,
+                                                          NVNtextureDepthStencilMode);
+typedef void (*nvnTextureViewSetTargetFunction)(NVNtextureView*, NVNtextureTarget);
+typedef bool (*nvnTextureViewGetLevelsFunction)(const NVNtextureView*, int*, int*);
+typedef bool (*nvnTextureViewGetLayersFunction)(const NVNtextureView*, int*, int*);
+typedef bool (*nvnTextureViewGetFormatFunction)(const NVNtextureView*, NVNformat*);
+typedef bool (*nvnTextureViewGetSwizzleFunction)(const NVNtextureView*, NVNtextureSwizzle*,
+                                                 NVNtextureSwizzle*, NVNtextureSwizzle*,
+                                                 NVNtextureSwizzle*);
+typedef bool (*nvnTextureViewGetDepthStencilModeFunction)(const NVNtextureView*,
+                                                          NVNtextureDepthStencilMode*);
+typedef bool (*nvnTextureViewGetTargetFunction)(const NVNtextureView*, NVNtextureTarget*);
+typedef bool (*nvnTextureViewCompareFunction)(const NVNtextureView*, const NVNtextureView*);
+typedef bool (*nvnTextureInitializeFunction)(NVNtexture*, const NVNtextureBuilder*);
+typedef size_t (*nvnTextureGetZCullStorageSizeFunction)(const NVNtexture*);
+typedef void (*nvnTextureFinalizeFunction)(NVNtexture*);
+typedef void (*nvnTextureSetDebugLabelFunction)(NVNtexture*, const char*);
+typedef NVNstorageClass (*nvnTextureGetStorageClassFunction)(const NVNtexture*);
+typedef ptrdiff_t (*nvnTextureGetViewOffsetFunction)(const NVNtexture*, const NVNtextureView*);
+typedef NVNtextureFlags (*nvnTextureGetFlagsFunction)(const NVNtexture*);
+typedef NVNtextureTarget (*nvnTextureGetTargetFunction)(const NVNtexture*);
+typedef int (*nvnTextureGetWidthFunction)(const NVNtexture*);
+typedef int (*nvnTextureGetHeightFunction)(const NVNtexture*);
+typedef int (*nvnTextureGetDepthFunction)(const NVNtexture*);
+typedef int (*nvnTextureGetLevelsFunction)(const NVNtexture*);
+typedef NVNformat (*nvnTextureGetFormatFunction)(const NVNtexture*);
+typedef int (*nvnTextureGetSamplesFunction)(const NVNtexture*);
+typedef void (*nvnTextureGetSwizzleFunction)(const NVNtexture*, NVNtextureSwizzle*,
+                                             NVNtextureSwizzle*, NVNtextureSwizzle*,
+                                             NVNtextureSwizzle*);
+typedef NVNtextureDepthStencilMode (*nvnTextureGetDepthStencilModeFunction)(const NVNtexture*);
+typedef ptrdiff_t (*nvnTextureGetStrideFunction)(const NVNtexture*);
+typedef NVNtextureAddress (*nvnTextureGetTextureAddressFunction)(const NVNtexture*);
+typedef void (*nvnTextureGetSparseTileLayoutFunction)(const NVNtexture*,
+                                                      NVNtextureSparseTileLayout*);
+typedef void (*nvnTextureWriteTexelsFunction)(const NVNtexture*, const NVNtextureView*,
+                                              const NVNcopyRegion*, const void*);
+typedef void (*nvnTextureWriteTexelsStridedFunction)(const NVNtexture*, const NVNtextureView*,
+                                                     const NVNcopyRegion*, const void*, ptrdiff_t,
+                                                     ptrdiff_t);
+typedef void (*nvnTextureReadTexelsFunction)(const NVNtexture*, const NVNtextureView*,
+                                             const NVNcopyRegion*, void*);
+typedef void (*nvnTextureReadTexelsStridedFunction)(const NVNtexture*, const NVNtextureView*,
+                                                    const NVNcopyRegion*, void*, ptrdiff_t,
+                                                    ptrdiff_t);
+typedef void (*nvnTextureFlushTexelsFunction)(const NVNtexture*, const NVNtextureView*,
+                                              const NVNcopyRegion*);
+typedef void (*nvnTextureInvalidateTexelsFunction)(const NVNtexture*, const NVNtextureView*,
+                                                   const NVNcopyRegion*);
+typedef NVNmemoryPool (*nvnTextureGetMemoryPoolFunction)(const NVNtexture*);
+typedef ptrdiff_t (*nvnTextureGetMemoryOffsetFunction)(const NVNtexture*);
+typedef int (*nvnTextureGetStorageSizeFunction)(const NVNtexture*);
+typedef bool (*nvnTextureCompareFunction)(const NVNtexture*, const NVNtexture*);
+typedef uint64_t (*nvnTextureGetDebugIDFunction)(const NVNtexture*);
+typedef void (*nvnSamplerBuilderSetDeviceFunction)(NVNsamplerBuilder*, NVNdevice*);
+typedef void (*nvnSamplerBuilderSetDefaultsFunction)(NVNsamplerBuilder*);
+typedef void (*nvnSamplerBuilderSetMinMagFilterFunction)(NVNsamplerBuilder*, NVNminFilter,
+                                                         NVNmagFilter);
+typedef void (*nvnSamplerBuilderSetWrapModeFunction)(NVNsamplerBuilder*, NVNwrapMode, NVNwrapMode,
+                                                     NVNwrapMode);
+typedef void (*nvnSamplerBuilderSetLodClampFunction)(NVNsamplerBuilder*, float, float);
+typedef void (*nvnSamplerBuilderSetLodBiasFunction)(NVNsamplerBuilder*, float);
+typedef void (*nvnSamplerBuilderSetCompareFunction)(NVNsamplerBuilder*, NVNcompareMode,
+                                                    NVNcompareFunc);
+typedef void (*nvnSamplerBuilderSetBorderColorFunction)(NVNsamplerBuilder*, const float*);
+typedef void (*nvnSamplerBuilderSetBorderColoriFunction)(NVNsamplerBuilder*, const int*);
+typedef void (*nvnSamplerBuilderSetBorderColoruiFunction)(NVNsamplerBuilder*, const uint32_t*);
+typedef void (*nvnSamplerBuilderSetMaxAnisotropyFunction)(NVNsamplerBuilder*, float);
+typedef void (*nvnSamplerBuilderSetReductionFilterFunction)(NVNsamplerBuilder*,
+                                                            NVNsamplerReduction);
+typedef void (*nvnSamplerBuilderSetLodSnapFunction)(NVNsamplerBuilder*, float);
+typedef void (*nvnSamplerBuilderGetMinMagFilterFunction)(const NVNsamplerBuilder*, NVNminFilter*,
+                                                         NVNmagFilter*);
+typedef void (*nvnSamplerBuilderGetWrapModeFunction)(const NVNsamplerBuilder*, NVNwrapMode*,
+                                                     NVNwrapMode*, NVNwrapMode*);
+typedef void (*nvnSamplerBuilderGetLodClampFunction)(const NVNsamplerBuilder*, float*, float*);
+typedef float (*nvnSamplerBuilderGetLodBiasFunction)(const NVNsamplerBuilder*);
+typedef void (*nvnSamplerBuilderGetCompareFunction)(const NVNsamplerBuilder*, NVNcompareMode*,
+                                                    NVNcompareFunc*);
+typedef void (*nvnSamplerBuilderGetBorderColorFunction)(const NVNsamplerBuilder*, float*);
+typedef void (*nvnSamplerBuilderGetBorderColoriFunction)(const NVNsamplerBuilder*, int*);
+typedef void (*nvnSamplerBuilderGetBorderColoruiFunction)(const NVNsamplerBuilder*, uint32_t*);
+typedef float (*nvnSamplerBuilderGetMaxAnisotropyFunction)(const NVNsamplerBuilder*);
+typedef NVNsamplerReduction (*nvnSamplerBuilderGetReductionFilterFunction)(
+    const NVNsamplerBuilder*);
+typedef float (*nvnSamplerBuilderGetLodSnapFunction)(const NVNsamplerBuilder*);
+typedef bool (*nvnSamplerInitializeFunction)(NVNsampler*, const NVNsamplerBuilder*);
+typedef void (*nvnSamplerFinalizeFunction)(NVNsampler*);
+typedef void (*nvnSamplerSetDebugLabelFunction)(NVNsampler*, const char*);
+typedef void (*nvnSamplerGetMinMagFilterFunction)(const NVNsampler*, NVNminFilter*, NVNmagFilter*);
+typedef void (*nvnSamplerGetWrapModeFunction)(const NVNsampler*, NVNwrapMode*, NVNwrapMode*,
+                                              NVNwrapMode*);
+typedef void (*nvnSamplerGetLodClampFunction)(const NVNsampler*, float*, float*);
+typedef float (*nvnSamplerGetLodBiasFunction)(const NVNsampler*);
+typedef void (*nvnSamplerGetCompareFunction)(const NVNsampler*, NVNcompareMode*, NVNcompareFunc*);
+typedef void (*nvnSamplerGetBorderColorFunction)(const NVNsampler*, float*);
+typedef void (*nvnSamplerGetBorderColoriFunction)(const NVNsampler*, int*);
+typedef void (*nvnSamplerGetBorderColoruiFunction)(const NVNsampler*, uint32_t*);
+typedef float (*nvnSamplerGetMaxAnisotropyFunction)(const NVNsampler*);
+typedef NVNsamplerReduction (*nvnSamplerGetReductionFilterFunction)(const NVNsampler*);
+typedef bool (*nvnSamplerCompareFunction)(const NVNsampler*, const NVNsampler*);
+typedef uint64_t (*nvnSamplerGetDebugIDFunction)(const NVNsampler*);
+typedef void (*nvnBlendStateSetDefaultsFunction)(NVNblendState*);
+typedef void (*nvnBlendStateSetBlendTargetFunction)(NVNblendState*, int);
+typedef void (*nvnBlendStateSetBlendFuncFunction)(NVNblendState*, NVNblendFunc, NVNblendFunc,
+                                                  NVNblendFunc, NVNblendFunc);
+typedef void (*nvnBlendStateSetBlendEquationFunction)(NVNblendState*, NVNblendEquation,
+                                                      NVNblendEquation);
+typedef void (*nvnBlendStateSetAdvancedModeFunction)(NVNblendState*, NVNblendAdvancedMode);
+typedef void (*nvnBlendStateSetAdvancedOverlapFunction)(NVNblendState*, NVNblendAdvancedOverlap);
+typedef void (*nvnBlendStateSetAdvancedPremultipliedSrcFunction)(NVNblendState*, bool);
+typedef void (*nvnBlendStateSetAdvancedNormalizedDstFunction)(NVNblendState*, bool);
+typedef int (*nvnBlendStateGetBlendTargetFunction)(const NVNblendState*);
+typedef void (*nvnBlendStateGetBlendFuncFunction)(const NVNblendState*, NVNblendFunc*,
+                                                  NVNblendFunc*, NVNblendFunc*, NVNblendFunc*);
+typedef void (*nvnBlendStateGetBlendEquationFunction)(const NVNblendState*, NVNblendEquation*,
+                                                      NVNblendEquation*);
+typedef NVNblendAdvancedMode (*nvnBlendStateGetAdvancedModeFunction)(const NVNblendState*);
+typedef NVNblendAdvancedOverlap (*nvnBlendStateGetAdvancedOverlapFunction)(const NVNblendState*);
+typedef bool (*nvnBlendStateGetAdvancedPremultipliedSrcFunction)(const NVNblendState*);
+typedef bool (*nvnBlendStateGetAdvancedNormalizedDstFunction)(const NVNblendState*);
+typedef void (*nvnColorStateSetDefaultsFunction)(NVNcolorState*);
+typedef void (*nvnColorStateSetBlendEnableFunction)(NVNcolorState*, int, bool);
+typedef void (*nvnColorStateSetLogicOpFunction)(NVNcolorState*, NVNlogicOp);
+typedef void (*nvnColorStateSetAlphaTestFunction)(NVNcolorState*, NVNalphaFunc);
+typedef bool (*nvnColorStateGetBlendEnableFunction)(const NVNcolorState*, int);
+typedef NVNlogicOp (*nvnColorStateGetLogicOpFunction)(const NVNcolorState*);
+typedef NVNalphaFunc (*nvnColorStateGetAlphaTestFunction)(const NVNcolorState*);
+typedef void (*nvnChannelMaskStateSetDefaultsFunction)(NVNchannelMaskState*);
+typedef void (*nvnChannelMaskStateSetChannelMaskFunction)(NVNchannelMaskState*, int, bool, bool,
+                                                          bool, bool);
+typedef void (*nvnChannelMaskStateGetChannelMaskFunction)(const NVNchannelMaskState*, int, bool*,
+                                                          bool*, bool*, bool*);
+typedef void (*nvnMultisampleStateSetDefaultsFunction)(NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetMultisampleEnableFunction)(NVNmultisampleState*, bool);
+typedef void (*nvnMultisampleStateSetSamplesFunction)(NVNmultisampleState*, int);
+typedef void (*nvnMultisampleStateSetAlphaToCoverageEnableFunction)(NVNmultisampleState*, bool);
+typedef void (*nvnMultisampleStateSetAlphaToCoverageDitherFunction)(NVNmultisampleState*, bool);
+typedef bool (*nvnMultisampleStateGetMultisampleEnableFunction)(const NVNmultisampleState*);
+typedef int (*nvnMultisampleStateGetSamplesFunction)(const NVNmultisampleState*);
+typedef bool (*nvnMultisampleStateGetAlphaToCoverageEnableFunction)(const NVNmultisampleState*);
+typedef bool (*nvnMultisampleStateGetAlphaToCoverageDitherFunction)(const NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetRasterSamplesFunction)(NVNmultisampleState*, int);
+typedef int (*nvnMultisampleStateGetRasterSamplesFunction)(NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetCoverageModulationModeFunction)(NVNmultisampleState*,
+                                                                     NVNcoverageModulationMode);
+typedef NVNcoverageModulationMode (*nvnMultisampleStateGetCoverageModulationModeFunction)(
+    const NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetCoverageToColorEnableFunction)(NVNmultisampleState*, bool);
+typedef bool (*nvnMultisampleStateGetCoverageToColorEnableFunction)(const NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetCoverageToColorOutputFunction)(NVNmultisampleState*, int);
+typedef int (*nvnMultisampleStateGetCoverageToColorOutputFunction)(const NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetSampleLocationsEnableFunction)(NVNmultisampleState*, bool);
+typedef bool (*nvnMultisampleStateGetSampleLocationsEnableFunction)(const NVNmultisampleState*);
+typedef void (*nvnMultisampleStateGetSampleLocationsGridFunction)(NVNmultisampleState*, int*, int*);
+typedef void (*nvnMultisampleStateSetSampleLocationsGridEnableFunction)(NVNmultisampleState*, bool);
+typedef bool (*nvnMultisampleStateGetSampleLocationsGridEnableFunction)(const NVNmultisampleState*);
+typedef void (*nvnMultisampleStateSetSampleLocationsFunction)(NVNmultisampleState*, bool);
+typedef void (*nvnPolygonStateSetDefaultsFunction)(NVNpolygonState*);
+typedef void (*nvnPolygonStateSetCullFaceFunction)(NVNpolygonState*, NVNface);
+typedef void (*nvnPolygonStateSetFrontFaceFunction)(NVNpolygonState*, NVNfrontFace);
+typedef void (*nvnPolygonStateSetPolygonModeFunction)(NVNpolygonState*, NVNpolygonMode);
+typedef void (*nvnPolygonStateSetPolygonOffsetEnablesFunction)(NVNpolygonState*, int);
+typedef NVNface (*nvnPolygonStateGetCullFaceFunction)(const NVNpolygonState*);
+typedef NVNfrontFace (*nvnPolygonStateGetFrontFaceFunction)(const NVNpolygonState*);
+typedef NVNpolygonMode (*nvnPolygonStateGetPolygonModeFunction)(const NVNpolygonState*);
+typedef NVNpolygonOffsetEnable (*nvnPolygonStateGetPolygonOffsetEnablesFunction)(
+    const NVNpolygonState*);
+typedef void (*nvnDepthStencilStateSetDefaultsFunction)(NVNdepthStencilState*);
+typedef void (*nvnDepthStencilStateSetDepthTestEnableFunction)(NVNdepthStencilState*, bool);
+typedef void (*nvnDepthStencilStateSetDepthWriteEnableFunction)(NVNdepthStencilState*, bool);
+typedef void (*nvnDepthStencilStateSetDepthFuncFunction)(NVNdepthStencilState*, NVNdepthFunc);
+typedef void (*nvnDepthStencilStateSetStencilTestEnableFunction)(NVNdepthStencilState*, bool);
+typedef void (*nvnDepthStencilStateSetStencilFuncFunction)(NVNdepthStencilState*, NVNface,
+                                                           NVNstencilFunc);
+typedef void (*nvnDepthStencilStateSetStencilOpFunction)(NVNdepthStencilState*, NVNface,
+                                                         NVNstencilOp, NVNstencilOp, NVNstencilOp);
+typedef bool (*nvnDepthStencilStateGetDepthTestEnableFunction)(const NVNdepthStencilState*);
+typedef bool (*nvnDepthStencilStateGetDepthWriteEnableFunction)(const NVNdepthStencilState*);
+typedef NVNdepthFunc (*nvnDepthStencilStateGetDepthFuncFunction)(const NVNdepthStencilState*);
+typedef bool (*nvnDepthStencilStateGetStencilTestEnableFunction)(const NVNdepthStencilState*);
+typedef NVNstencilFunc (*nvnDepthStencilStateGetStencilFuncFunction)(const NVNdepthStencilState*,
+                                                                     NVNface);
+typedef void (*nvnDepthStencilStateGetStencilOpFunction)(const NVNdepthStencilState*, NVNface,
+                                                         NVNstencilOp*, NVNstencilOp*,
+                                                         NVNstencilOp*);
+typedef void (*nvnVertexAttribStateSetDefaultsFunction)(NVNvertexAttribState*);
+typedef void (*nvnVertexAttribStateSetFormatFunction)(NVNvertexAttribState*, NVNformat, ptrdiff_t);
+typedef void (*nvnVertexAttribStateSetStreamIndexFunction)(NVNvertexAttribState*, int);
+typedef void (*nvnVertexAttribStateGetFormatFunction)(const NVNvertexAttribState*, NVNformat*,
+                                                      ptrdiff_t*);
+typedef int (*nvnVertexAttribStateGetStreamIndexFunction)(const NVNvertexAttribState*);
+typedef void (*nvnVertexStreamStateSetDefaultsFunction)(NVNvertexStreamState*);
+typedef void (*nvnVertexStreamStateSetStrideFunction)(NVNvertexStreamState*, ptrdiff_t);
+typedef void (*nvnVertexStreamStateSetDivisorFunction)(NVNvertexStreamState*, int);
+typedef ptrdiff_t (*nvnVertexStreamStateGetStrideFunction)(const NVNvertexStreamState*);
+typedef int (*nvnVertexStreamStateGetDivisorFunction)(const NVNvertexStreamState*);
+typedef bool (*nvnCommandBufferInitializeFunction)(NVNcommandBuffer*, NVNdevice*);
+typedef void (*nvnCommandBufferFinalizeFunction)(NVNcommandBuffer*);
+typedef void (*nvnCommandBufferSetDebugLabelFunction)(NVNcommandBuffer*, const char*);
+typedef void (*nvnCommandBufferSetMemoryCallbackFunction)(NVNcommandBuffer*,
+                                                          NVNcommandBufferMemoryCallback);
+typedef void (*nvnCommandBufferSetMemoryCallbackDataFunction)(NVNcommandBuffer*, void*);
+typedef void (*nvnCommandBufferAddCommandMemoryFunction)(NVNcommandBuffer*, const NVNmemoryPool*,
+                                                         ptrdiff_t, size_t);
+typedef void (*nvnCommandBufferAddControlMemoryFunction)(NVNcommandBuffer*, void*, size_t);
+typedef size_t (*nvnCommandBufferGetCommandMemorySizeFunction)(const NVNcommandBuffer*);
+typedef size_t (*nvnCommandBufferGetCommandMemoryUsedFunction)(const NVNcommandBuffer*);
+typedef size_t (*nvnCommandBufferGetCommandMemoryFreeFunction)(const NVNcommandBuffer*);
+typedef size_t (*nvnCommandBufferGetControlMemorySizeFunction)(const NVNcommandBuffer*);
+typedef size_t (*nvnCommandBufferGetControlMemoryUsedFunction)(const NVNcommandBuffer*);
+typedef size_t (*nvnCommandBufferGetControlMemoryFreeFunction)(const NVNcommandBuffer*);
+typedef void (*nvnCommandBufferBeginRecordingFunction)(NVNcommandBuffer*);
+typedef NVNcommandHandle (*nvnCommandBufferEndRecordingFunction)(NVNcommandBuffer*);
+typedef void (*nvnCommandBufferCallCommandsFunction)(NVNcommandBuffer*, int,
+                                                     const NVNcommandHandle*);
+typedef void (*nvnCommandBufferCopyCommandsFunction)(NVNcommandBuffer*, int,
+                                                     const NVNcommandHandle*);
+typedef void (*nvnCommandBufferBindBlendStateFunction)(NVNcommandBuffer*, const NVNblendState*);
+typedef void (*nvnCommandBufferBindChannelMaskStateFunction)(NVNcommandBuffer*,
+                                                             const NVNchannelMaskState*);
+typedef void (*nvnCommandBufferBindColorStateFunction)(NVNcommandBuffer*, const NVNcolorState*);
+typedef void (*nvnCommandBufferBindMultisampleStateFunction)(NVNcommandBuffer*,
+                                                             const NVNmultisampleState*);
+typedef void (*nvnCommandBufferBindPolygonStateFunction)(NVNcommandBuffer*, const NVNpolygonState*);
+typedef void (*nvnCommandBufferBindDepthStencilStateFunction)(NVNcommandBuffer*,
+                                                              const NVNdepthStencilState*);
+typedef void (*nvnCommandBufferBindVertexAttribStateFunction)(NVNcommandBuffer*, int,
+                                                              const NVNvertexAttribState*);
+typedef void (*nvnCommandBufferBindVertexStreamStateFunction)(NVNcommandBuffer*, int,
+                                                              const NVNvertexStreamState*);
+typedef void (*nvnCommandBufferBindProgramFunction)(NVNcommandBuffer*, const NVNprogram*, int);
+typedef void (*nvnCommandBufferBindVertexBufferFunction)(NVNcommandBuffer*, int, NVNbufferAddress,
+                                                         size_t);
+typedef void (*nvnCommandBufferBindVertexBuffersFunction)(NVNcommandBuffer*, int, int,
+                                                          const NVNbufferRange*);
+typedef void (*nvnCommandBufferBindUniformBufferFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                          NVNbufferAddress, size_t);
+typedef void (*nvnCommandBufferBindUniformBuffersFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                           int, const NVNbufferRange*);
+typedef void (*nvnCommandBufferBindTransformFeedbackBufferFunction)(NVNcommandBuffer*, int,
+                                                                    NVNbufferAddress, size_t);
+typedef void (*nvnCommandBufferBindTransformFeedbackBuffersFunction)(NVNcommandBuffer*, int, int,
+                                                                     const NVNbufferRange*);
+typedef void (*nvnCommandBufferBindStorageBufferFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                          NVNbufferAddress, size_t);
+typedef void (*nvnCommandBufferBindStorageBuffersFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                           int, const NVNbufferRange*);
+typedef void (*nvnCommandBufferBindTextureFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                    NVNtextureHandle);
+typedef void (*nvnCommandBufferBindTexturesFunction)(NVNcommandBuffer*, NVNshaderStage, int, int,
+                                                     const NVNtextureHandle*);
+typedef void (*nvnCommandBufferBindImageFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                  NVNimageHandle);
+typedef void (*nvnCommandBufferBindImagesFunction)(NVNcommandBuffer*, NVNshaderStage, int, int,
+                                                   const NVNimageHandle*);
+typedef void (*nvnCommandBufferSetPatchSizeFunction)(NVNcommandBuffer*, int);
+typedef void (*nvnCommandBufferSetInnerTessellationLevelsFunction)(NVNcommandBuffer*, const float*);
+typedef void (*nvnCommandBufferSetOuterTessellationLevelsFunction)(NVNcommandBuffer*, const float*);
+typedef void (*nvnCommandBufferSetPrimitiveRestartFunction)(NVNcommandBuffer*, bool, int);
+typedef void (*nvnCommandBufferBeginTransformFeedbackFunction)(NVNcommandBuffer*, NVNbufferAddress);
+typedef void (*nvnCommandBufferEndTransformFeedbackFunction)(NVNcommandBuffer*, NVNbufferAddress);
+typedef void (*nvnCommandBufferPauseTransformFeedbackFunction)(NVNcommandBuffer*, NVNbufferAddress);
+typedef void (*nvnCommandBufferResumeTransformFeedbackFunction)(NVNcommandBuffer*,
+                                                                NVNbufferAddress);
+typedef void (*nvnCommandBufferDrawTransformFeedbackFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                              NVNbufferAddress);
+typedef void (*nvnCommandBufferDrawArraysFunction)(NVNcommandBuffer*, NVNdrawPrimitive, int, int);
+typedef void (*nvnCommandBufferDrawElementsFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                     NVNindexType, int, NVNbufferAddress);
+typedef void (*nvnCommandBufferDrawElementsBaseVertexFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                               NVNindexType, int, NVNbufferAddress,
+                                                               int);
+typedef void (*nvnCommandBufferDrawArraysInstancedFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                            int, int, int, int);
+typedef void (*nvnCommandBufferDrawElementsInstancedFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                              NVNindexType, int, NVNbufferAddress,
+                                                              int, int, int);
+typedef void (*nvnCommandBufferDrawArraysIndirectFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                           NVNbufferAddress);
+typedef void (*nvnCommandBufferDrawElementsIndirectFunction)(NVNcommandBuffer*, NVNdrawPrimitive,
+                                                             NVNindexType, NVNbufferAddress,
+                                                             NVNbufferAddress);
+typedef void (*nvnCommandBufferMultiDrawArraysIndirectCountFunction)(
+    NVNcommandBuffer*, NVNdrawPrimitive, NVNbufferAddress, NVNbufferAddress, int, ptrdiff_t);
+typedef void (*nvnCommandBufferMultiDrawElementsIndirectCountFunction)(
+    NVNcommandBuffer*, NVNdrawPrimitive, NVNindexType, NVNbufferAddress, NVNbufferAddress,
+    NVNbufferAddress, int, ptrdiff_t);
+typedef void (*nvnCommandBufferClearColorFunction)(NVNcommandBuffer*, int, const float*, int);
+typedef void (*nvnCommandBufferClearColoriFunction)(NVNcommandBuffer*, int, const int*, int);
+typedef void (*nvnCommandBufferClearColoruiFunction)(NVNcommandBuffer*, int, const uint32_t*, int);
+typedef void (*nvnCommandBufferClearDepthStencilFunction)(NVNcommandBuffer*, float, bool, int, int);
+typedef void (*nvnCommandBufferDispatchComputeFunction)(NVNcommandBuffer*, int, int, int);
+typedef void (*nvnCommandBufferDispatchComputeIndirectFunction)(NVNcommandBuffer*,
+                                                                NVNbufferAddress);
+typedef void (*nvnCommandBufferSetViewportFunction)(NVNcommandBuffer*, int, int, int, int);
+typedef void (*nvnCommandBufferSetViewportsFunction)(NVNcommandBuffer*, int, int, const float*);
+typedef void (*nvnCommandBufferSetViewportSwizzlesFunction)(NVNcommandBuffer*, int, int,
+                                                            const NVNviewportSwizzle*);
+typedef void (*nvnCommandBufferSetScissorFunction)(NVNcommandBuffer*, int, int, int, int);
+typedef void (*nvnCommandBufferSetScissorsFunction)(NVNcommandBuffer*, int, int, const int*);
+typedef void (*nvnCommandBufferSetDepthRangeFunction)(NVNcommandBuffer*, float, float);
+typedef void (*nvnCommandBufferSetDepthBoundsFunction)(NVNcommandBuffer*, bool, float, float);
+typedef void (*nvnCommandBufferSetDepthRangesFunction)(NVNcommandBuffer*, int, int, const float*);
+typedef void (*nvnCommandBufferSetTiledCacheActionFunction)(NVNcommandBuffer*, NVNtiledCacheAction);
+typedef void (*nvnCommandBufferSetTiledCacheTileSizeFunction)(NVNcommandBuffer*, int, int);
+typedef void (*nvnCommandBufferBindSeparateTextureFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                            NVNseparateTextureHandle);
+typedef void (*nvnCommandBufferBindSeparateSamplerFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                            NVNseparateSamplerHandle);
+typedef void (*nvnCommandBufferBindSeparateTexturesFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                             int, const NVNseparateTextureHandle*);
+typedef void (*nvnCommandBufferBindSeparateSamplersFunction)(NVNcommandBuffer*, NVNshaderStage, int,
+                                                             int, const NVNseparateSamplerHandle*);
+typedef void (*nvnCommandBufferSetStencilValueMaskFunction)(NVNcommandBuffer*, NVNface, int);
+typedef void (*nvnCommandBufferSetStencilMaskFunction)(NVNcommandBuffer*, NVNface, int);
+typedef void (*nvnCommandBufferSetStencilRefFunction)(NVNcommandBuffer*, NVNface, int);
+typedef void (*nvnCommandBufferSetBlendColorFunction)(NVNcommandBuffer*, const float*);
+typedef void (*nvnCommandBufferSetPointSizeFunction)(NVNcommandBuffer*, float);
+typedef void (*nvnCommandBufferSetLineWidthFunction)(NVNcommandBuffer*, float);
+typedef void (*nvnCommandBufferSetPolygonOffsetClampFunction)(NVNcommandBuffer*, float, float,
+                                                              float);
+typedef void (*nvnCommandBufferSetAlphaRefFunction)(NVNcommandBuffer*, float);
+typedef void (*nvnCommandBufferSetSampleMaskFunction)(NVNcommandBuffer*, int);
+typedef void (*nvnCommandBufferSetRasterizerDiscardFunction)(NVNcommandBuffer*, bool);
+typedef void (*nvnCommandBufferSetDepthClampFunction)(NVNcommandBuffer*, bool);
+typedef void (*nvnCommandBufferSetConservativeRasterEnableFunction)(NVNcommandBuffer*, bool);
+typedef void (*nvnCommandBufferSetConservativeRasterDilateFunction)(NVNcommandBuffer*, float);
+typedef void (*nvnCommandBufferSetSubpixelPrecisionBiasFunction)(NVNcommandBuffer*, int, int);
+typedef void (*nvnCommandBufferCopyBufferToTextureFunction)(NVNcommandBuffer*, NVNbufferAddress,
+                                                            const NVNtexture*,
+                                                            const NVNtextureView*,
+                                                            const NVNcopyRegion*, int);
+typedef void (*nvnCommandBufferCopyTextureToBufferFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                            const NVNtextureView*,
+                                                            const NVNcopyRegion*, NVNbufferAddress,
+                                                            int);
+typedef void (*nvnCommandBufferCopyTextureToTextureFunction)(
+    NVNcommandBuffer*, const NVNtexture*, const NVNtextureView*, const NVNcopyRegion*,
+    const NVNtexture*, const NVNtextureView*, const NVNcopyRegion*, int);
+typedef void (*nvnCommandBufferCopyBufferToBufferFunction)(NVNcommandBuffer*, NVNbufferAddress,
+                                                           NVNbufferAddress, size_t, int);
+typedef void (*nvnCommandBufferClearBufferFunction)(NVNcommandBuffer*, NVNbufferAddress, size_t,
+                                                    uint32_t);
+typedef void (*nvnCommandBufferClearTextureFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                     const NVNtextureView*, const NVNcopyRegion*,
+                                                     const float*, int);
+typedef void (*nvnCommandBufferClearTextureiFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                      const NVNtextureView*, const NVNcopyRegion*,
+                                                      const int*, int);
+typedef void (*nvnCommandBufferClearTextureuiFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                       const NVNtextureView*, const NVNcopyRegion*,
+                                                       const uint32_t*, int);
+typedef void (*nvnCommandBufferUpdateUniformBufferFunction)(NVNcommandBuffer*, NVNbufferAddress,
+                                                            size_t, ptrdiff_t, size_t, const void*);
+typedef void (*nvnCommandBufferReportCounterFunction)(NVNcommandBuffer*, NVNcounterType,
+                                                      NVNbufferAddress);
+typedef void (*nvnCommandBufferResetCounterFunction)(NVNcommandBuffer*, NVNcounterType);
+typedef void (*nvnCommandBufferReportValueFunction)(NVNcommandBuffer*, uint32_t, NVNbufferAddress);
+typedef void (*nvnCommandBufferSetRenderEnableFunction)(NVNcommandBuffer*, bool);
+typedef void (*nvnCommandBufferSetRenderEnableConditionalFunction)(NVNcommandBuffer*,
+                                                                   NVNconditionalRenderMode,
+                                                                   NVNbufferAddress);
+typedef void (*nvnCommandBufferSetRenderTargetsFunction)(NVNcommandBuffer*, int,
+                                                         const NVNtexture* const*,
+                                                         const NVNtextureView* const*,
+                                                         const NVNtexture*, const NVNtextureView*);
+typedef void (*nvnCommandBufferDiscardColorFunction)(NVNcommandBuffer*, int);
+typedef void (*nvnCommandBufferDiscardDepthStencilFunction)(NVNcommandBuffer*);
+typedef void (*nvnCommandBufferDownsampleFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                   const NVNtexture*);
+typedef void (*nvnCommandBufferTiledDownsampleFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                        const NVNtexture*);
+typedef void (*nvnCommandBufferDownsampleTextureViewFunction)(NVNcommandBuffer*, const NVNtexture*,
+                                                              const NVNtextureView*,
+                                                              const NVNtexture*,
+                                                              const NVNtextureView*);
+typedef void (*nvnCommandBufferTiledDownsampleTextureViewFunction)(NVNcommandBuffer*,
+                                                                   const NVNtexture*,
+                                                                   const NVNtextureView*,
+                                                                   const NVNtexture*,
+                                                                   const NVNtextureView*);
+typedef void (*nvnCommandBufferBarrierFunction)(NVNcommandBuffer*, int);
+typedef void (*nvnCommandBufferWaitSyncFunction)(NVNcommandBuffer*, const NVNsync*);
+typedef void (*nvnCommandBufferFenceSyncFunction)(NVNcommandBuffer*, NVNsync*, NVNsyncCondition,
+                                                  int);
+typedef void (*nvnCommandBufferSetTexturePoolFunction)(NVNcommandBuffer*, const NVNtexturePool*);
+typedef void (*nvnCommandBufferSetSamplerPoolFunction)(NVNcommandBuffer*, const NVNsamplerPool*);
+typedef void (*nvnCommandBufferSetShaderScratchMemoryFunction)(NVNcommandBuffer*,
+                                                               const NVNmemoryPool*, ptrdiff_t,
+                                                               size_t);
+typedef void (*nvnCommandBufferSaveZCullDataFunction)(NVNcommandBuffer*, NVNbufferAddress, size_t);
+typedef void (*nvnCommandBufferRestoreZCullDataFunction)(NVNcommandBuffer*, NVNbufferAddress,
+                                                         size_t);
+typedef void (*nvnCommandBufferSetCopyRowStrideFunction)(NVNcommandBuffer*, ptrdiff_t);
+typedef void (*nvnCommandBufferSetCopyImageStrideFunction)(NVNcommandBuffer*, ptrdiff_t);
+typedef ptrdiff_t (*nvnCommandBufferGetCopyRowStrideFunction)(const NVNcommandBuffer*);
+typedef ptrdiff_t (*nvnCommandBufferGetCopyImageStrideFunction)(const NVNcommandBuffer*);
+typedef void (*nvnCommandBufferDrawTextureFunction)(NVNcommandBuffer*, NVNtextureHandle,
+                                                    const NVNdrawTextureRegion*,
+                                                    const NVNdrawTextureRegion*);
+typedef bool (*nvnProgramSetSubroutineLinkageFunction)(NVNprogram*, int,
+                                                       const NVNsubroutineLinkageMapPtr*);
+typedef void (*nvnCommandBufferSetProgramSubroutinesFunction)(NVNcommandBuffer*, NVNprogram*,
+                                                              NVNshaderStage, const int, const int,
+                                                              const int*);
+typedef void (*nvnCommandBufferBindCoverageModulationTableFunction)(NVNcommandBuffer*,
+                                                                    const float*);
+typedef void (*nvnCommandBufferResolveDepthBufferFunction)(NVNcommandBuffer*);
+typedef void (*nvnCommandBufferPushDebugGroupStaticFunction)(NVNcommandBuffer*, uint32_t,
+                                                             const char*);
+typedef void (*nvnCommandBufferPushDebugGroupDynamicFunction)(NVNcommandBuffer*, uint32_t,
+                                                              const char*);
+typedef void (*nvnCommandBufferPushDebugGroupFunction)(NVNcommandBuffer*, uint32_t, const char*);
+typedef void (*nvnCommandBufferPopDebugGroupFunction)(NVNcommandBuffer*);
+typedef void (*nvnCommandBufferPopDebugGroupIdFunction)(NVNcommandBuffer*, uint32_t);
+typedef void (*nvnCommandBufferInsertDebugMarkerStaticFunction)(NVNcommandBuffer*, uint32_t,
+                                                                const char*);
+typedef void (*nvnCommandBufferInsertDebugMarkerDynamicFunction)(NVNcommandBuffer*, uint32_t,
+                                                                 const char*);
+typedef void (*nvnCommandBufferInsertDebugMarkerFunction)(NVNcommandBuffer*, uint32_t, const char*);
+typedef NVNcommandBufferMemoryCallback (*nvnCommandBufferGetMemoryCallbackFunction)(
+    const NVNcommandBuffer*);
+typedef void (*nvnCommandBufferGetMemoryCallbackDataFunction)(const NVNcommandBuffer*);
+typedef bool (*nvnCommandBufferIsRecordingFunction)(const NVNcommandBuffer*);
+typedef bool (*nvnSyncInitializeFunction)(NVNsync*, NVNdevice*);
+typedef void (*nvnSyncFinalizeFunction)(NVNsync*);
+typedef void (*nvnSyncSetDebugLabelFunction)(NVNsync*, const char*);
+typedef void (*nvnQueueFenceSyncFunction)(NVNqueue*, NVNsync*, NVNsyncCondition, int);
+typedef NVNsyncWaitResult (*nvnSyncWaitFunction)(const NVNsync*, uint64_t);
+typedef bool (*nvnQueueWaitSyncFunction)(NVNqueue*, const NVNsync*);
+typedef void (*nvnEventBuilderSetDefaultsFunction)(NVNeventBuilder*);
+typedef void (*nvnEventBuilderSetStorageFunction)(NVNeventBuilder*, const NVNmemoryPool*, int64_t);
+typedef bool (*nvnEventInitializeFunction)(NVNevent*, const NVNeventBuilder*);
+typedef void (*nvnEventFinalizeFunction)(NVNevent*);
+typedef uint32_t (*nvnEventGetValueFunction)(const NVNevent*);
+typedef void (*nvnEventSignalFunction)(NVNevent*, NVNeventSignalMode, uint32_t);
+typedef void (*nvnCommandBufferWaitEventFunction)(NVNcommandBuffer*, const NVNevent*,
+                                                  NVNeventWaitMode, uint32_t);
+typedef void (*nvnCommandBufferSignalEventFunction)(NVNcommandBuffer*, const NVNevent*,
+                                                    NVNeventSignalMode, NVNeventSignalLocation, int,
+                                                    uint32_t);
 
 // Function pointer definitions
 extern nvnDeviceBuilderSetDefaultsFunction pfnc_nvnDeviceBuilderSetDefaults;
@@ -496,7 +650,8 @@ extern nvnDeviceFinalizeFunction pfnc_nvnDeviceFinalize;
 extern nvnDeviceSetDebugLabelFunction pfnc_nvnDeviceSetDebugLabel;
 extern nvnDeviceGetProcAddressFunction pfnc_nvnDeviceGetProcAddress;
 extern nvnDeviceGetIntegerFunction pfnc_nvnDeviceGetInteger;
-extern nvnDeviceGetCurrentTimestampInNanosecondsFunction pfnc_nvnDeviceGetCurrentTimestampInNanoseconds;
+extern nvnDeviceGetCurrentTimestampInNanosecondsFunction
+    pfnc_nvnDeviceGetCurrentTimestampInNanoseconds;
 extern nvnDeviceSetIntermediateShaderCacheFunction pfnc_nvnDeviceSetIntermediateShaderCache;
 extern nvnDeviceGetTextureHandleFunction pfnc_nvnDeviceGetTextureHandle;
 extern nvnDeviceGetTexelFetchHandleFunction pfnc_nvnDeviceGetTexelFetchHandle;
@@ -629,7 +784,8 @@ extern nvnTextureBuilderGetStorageSizeFunction pfnc_nvnTextureBuilderGetStorageS
 extern nvnTextureBuilderGetStorageAlignmentFunction pfnc_nvnTextureBuilderGetStorageAlignment;
 extern nvnTextureBuilderSetStorageFunction pfnc_nvnTextureBuilderSetStorage;
 extern nvnTextureBuilderSetPackagedTextureDataFunction pfnc_nvnTextureBuilderSetPackagedTextureData;
-extern nvnTextureBuilderSetPackagedTextureLayoutFunction pfnc_nvnTextureBuilderSetPackagedTextureLayout;
+extern nvnTextureBuilderSetPackagedTextureLayoutFunction
+    pfnc_nvnTextureBuilderSetPackagedTextureLayout;
 extern nvnTextureBuilderSetStrideFunction pfnc_nvnTextureBuilderSetStride;
 extern nvnTextureBuilderSetGLTextureNameFunction pfnc_nvnTextureBuilderSetGLTextureName;
 extern nvnTextureBuilderGetStorageClassFunction pfnc_nvnTextureBuilderGetStorageClass;
@@ -739,14 +895,16 @@ extern nvnBlendStateSetBlendFuncFunction pfnc_nvnBlendStateSetBlendFunc;
 extern nvnBlendStateSetBlendEquationFunction pfnc_nvnBlendStateSetBlendEquation;
 extern nvnBlendStateSetAdvancedModeFunction pfnc_nvnBlendStateSetAdvancedMode;
 extern nvnBlendStateSetAdvancedOverlapFunction pfnc_nvnBlendStateSetAdvancedOverlap;
-extern nvnBlendStateSetAdvancedPremultipliedSrcFunction pfnc_nvnBlendStateSetAdvancedPremultipliedSrc;
+extern nvnBlendStateSetAdvancedPremultipliedSrcFunction
+    pfnc_nvnBlendStateSetAdvancedPremultipliedSrc;
 extern nvnBlendStateSetAdvancedNormalizedDstFunction pfnc_nvnBlendStateSetAdvancedNormalizedDst;
 extern nvnBlendStateGetBlendTargetFunction pfnc_nvnBlendStateGetBlendTarget;
 extern nvnBlendStateGetBlendFuncFunction pfnc_nvnBlendStateGetBlendFunc;
 extern nvnBlendStateGetBlendEquationFunction pfnc_nvnBlendStateGetBlendEquation;
 extern nvnBlendStateGetAdvancedModeFunction pfnc_nvnBlendStateGetAdvancedMode;
 extern nvnBlendStateGetAdvancedOverlapFunction pfnc_nvnBlendStateGetAdvancedOverlap;
-extern nvnBlendStateGetAdvancedPremultipliedSrcFunction pfnc_nvnBlendStateGetAdvancedPremultipliedSrc;
+extern nvnBlendStateGetAdvancedPremultipliedSrcFunction
+    pfnc_nvnBlendStateGetAdvancedPremultipliedSrc;
 extern nvnBlendStateGetAdvancedNormalizedDstFunction pfnc_nvnBlendStateGetAdvancedNormalizedDst;
 extern nvnColorStateSetDefaultsFunction pfnc_nvnColorStateSetDefaults;
 extern nvnColorStateSetBlendEnableFunction pfnc_nvnColorStateSetBlendEnable;
@@ -761,25 +919,40 @@ extern nvnChannelMaskStateGetChannelMaskFunction pfnc_nvnChannelMaskStateGetChan
 extern nvnMultisampleStateSetDefaultsFunction pfnc_nvnMultisampleStateSetDefaults;
 extern nvnMultisampleStateSetMultisampleEnableFunction pfnc_nvnMultisampleStateSetMultisampleEnable;
 extern nvnMultisampleStateSetSamplesFunction pfnc_nvnMultisampleStateSetSamples;
-extern nvnMultisampleStateSetAlphaToCoverageEnableFunction pfnc_nvnMultisampleStateSetAlphaToCoverageEnable;
-extern nvnMultisampleStateSetAlphaToCoverageDitherFunction pfnc_nvnMultisampleStateSetAlphaToCoverageDither;
+extern nvnMultisampleStateSetAlphaToCoverageEnableFunction
+    pfnc_nvnMultisampleStateSetAlphaToCoverageEnable;
+extern nvnMultisampleStateSetAlphaToCoverageDitherFunction
+    pfnc_nvnMultisampleStateSetAlphaToCoverageDither;
 extern nvnMultisampleStateGetMultisampleEnableFunction pfnc_nvnMultisampleStateGetMultisampleEnable;
 extern nvnMultisampleStateGetSamplesFunction pfnc_nvnMultisampleStateGetSamples;
-extern nvnMultisampleStateGetAlphaToCoverageEnableFunction pfnc_nvnMultisampleStateGetAlphaToCoverageEnable;
-extern nvnMultisampleStateGetAlphaToCoverageDitherFunction pfnc_nvnMultisampleStateGetAlphaToCoverageDither;
+extern nvnMultisampleStateGetAlphaToCoverageEnableFunction
+    pfnc_nvnMultisampleStateGetAlphaToCoverageEnable;
+extern nvnMultisampleStateGetAlphaToCoverageDitherFunction
+    pfnc_nvnMultisampleStateGetAlphaToCoverageDither;
 extern nvnMultisampleStateSetRasterSamplesFunction pfnc_nvnMultisampleStateSetRasterSamples;
 extern nvnMultisampleStateGetRasterSamplesFunction pfnc_nvnMultisampleStateGetRasterSamples;
-extern nvnMultisampleStateSetCoverageModulationModeFunction pfnc_nvnMultisampleStateSetCoverageModulationMode;
-extern nvnMultisampleStateGetCoverageModulationModeFunction pfnc_nvnMultisampleStateGetCoverageModulationMode;
-extern nvnMultisampleStateSetCoverageToColorEnableFunction pfnc_nvnMultisampleStateSetCoverageToColorEnable;
-extern nvnMultisampleStateGetCoverageToColorEnableFunction pfnc_nvnMultisampleStateGetCoverageToColorEnable;
-extern nvnMultisampleStateSetCoverageToColorOutputFunction pfnc_nvnMultisampleStateSetCoverageToColorOutput;
-extern nvnMultisampleStateGetCoverageToColorOutputFunction pfnc_nvnMultisampleStateGetCoverageToColorOutput;
-extern nvnMultisampleStateSetSampleLocationsEnableFunction pfnc_nvnMultisampleStateSetSampleLocationsEnable;
-extern nvnMultisampleStateGetSampleLocationsEnableFunction pfnc_nvnMultisampleStateGetSampleLocationsEnable;
-extern nvnMultisampleStateGetSampleLocationsGridFunction pfnc_nvnMultisampleStateGetSampleLocationsGrid;
-extern nvnMultisampleStateSetSampleLocationsGridEnableFunction pfnc_nvnMultisampleStateSetSampleLocationsGridEnable;
-extern nvnMultisampleStateGetSampleLocationsGridEnableFunction pfnc_nvnMultisampleStateGetSampleLocationsGridEnable;
+extern nvnMultisampleStateSetCoverageModulationModeFunction
+    pfnc_nvnMultisampleStateSetCoverageModulationMode;
+extern nvnMultisampleStateGetCoverageModulationModeFunction
+    pfnc_nvnMultisampleStateGetCoverageModulationMode;
+extern nvnMultisampleStateSetCoverageToColorEnableFunction
+    pfnc_nvnMultisampleStateSetCoverageToColorEnable;
+extern nvnMultisampleStateGetCoverageToColorEnableFunction
+    pfnc_nvnMultisampleStateGetCoverageToColorEnable;
+extern nvnMultisampleStateSetCoverageToColorOutputFunction
+    pfnc_nvnMultisampleStateSetCoverageToColorOutput;
+extern nvnMultisampleStateGetCoverageToColorOutputFunction
+    pfnc_nvnMultisampleStateGetCoverageToColorOutput;
+extern nvnMultisampleStateSetSampleLocationsEnableFunction
+    pfnc_nvnMultisampleStateSetSampleLocationsEnable;
+extern nvnMultisampleStateGetSampleLocationsEnableFunction
+    pfnc_nvnMultisampleStateGetSampleLocationsEnable;
+extern nvnMultisampleStateGetSampleLocationsGridFunction
+    pfnc_nvnMultisampleStateGetSampleLocationsGrid;
+extern nvnMultisampleStateSetSampleLocationsGridEnableFunction
+    pfnc_nvnMultisampleStateSetSampleLocationsGridEnable;
+extern nvnMultisampleStateGetSampleLocationsGridEnableFunction
+    pfnc_nvnMultisampleStateGetSampleLocationsGridEnable;
 extern nvnMultisampleStateSetSampleLocationsFunction pfnc_nvnMultisampleStateSetSampleLocations;
 extern nvnPolygonStateSetDefaultsFunction pfnc_nvnPolygonStateSetDefaults;
 extern nvnPolygonStateSetCullFaceFunction pfnc_nvnPolygonStateSetCullFace;
@@ -794,13 +967,15 @@ extern nvnDepthStencilStateSetDefaultsFunction pfnc_nvnDepthStencilStateSetDefau
 extern nvnDepthStencilStateSetDepthTestEnableFunction pfnc_nvnDepthStencilStateSetDepthTestEnable;
 extern nvnDepthStencilStateSetDepthWriteEnableFunction pfnc_nvnDepthStencilStateSetDepthWriteEnable;
 extern nvnDepthStencilStateSetDepthFuncFunction pfnc_nvnDepthStencilStateSetDepthFunc;
-extern nvnDepthStencilStateSetStencilTestEnableFunction pfnc_nvnDepthStencilStateSetStencilTestEnable;
+extern nvnDepthStencilStateSetStencilTestEnableFunction
+    pfnc_nvnDepthStencilStateSetStencilTestEnable;
 extern nvnDepthStencilStateSetStencilFuncFunction pfnc_nvnDepthStencilStateSetStencilFunc;
 extern nvnDepthStencilStateSetStencilOpFunction pfnc_nvnDepthStencilStateSetStencilOp;
 extern nvnDepthStencilStateGetDepthTestEnableFunction pfnc_nvnDepthStencilStateGetDepthTestEnable;
 extern nvnDepthStencilStateGetDepthWriteEnableFunction pfnc_nvnDepthStencilStateGetDepthWriteEnable;
 extern nvnDepthStencilStateGetDepthFuncFunction pfnc_nvnDepthStencilStateGetDepthFunc;
-extern nvnDepthStencilStateGetStencilTestEnableFunction pfnc_nvnDepthStencilStateGetStencilTestEnable;
+extern nvnDepthStencilStateGetStencilTestEnableFunction
+    pfnc_nvnDepthStencilStateGetStencilTestEnable;
 extern nvnDepthStencilStateGetStencilFuncFunction pfnc_nvnDepthStencilStateGetStencilFunc;
 extern nvnDepthStencilStateGetStencilOpFunction pfnc_nvnDepthStencilStateGetStencilOp;
 extern nvnVertexAttribStateSetDefaultsFunction pfnc_nvnVertexAttribStateSetDefaults;
@@ -843,8 +1018,10 @@ extern nvnCommandBufferBindVertexBufferFunction pfnc_nvnCommandBufferBindVertexB
 extern nvnCommandBufferBindVertexBuffersFunction pfnc_nvnCommandBufferBindVertexBuffers;
 extern nvnCommandBufferBindUniformBufferFunction pfnc_nvnCommandBufferBindUniformBuffer;
 extern nvnCommandBufferBindUniformBuffersFunction pfnc_nvnCommandBufferBindUniformBuffers;
-extern nvnCommandBufferBindTransformFeedbackBufferFunction pfnc_nvnCommandBufferBindTransformFeedbackBuffer;
-extern nvnCommandBufferBindTransformFeedbackBuffersFunction pfnc_nvnCommandBufferBindTransformFeedbackBuffers;
+extern nvnCommandBufferBindTransformFeedbackBufferFunction
+    pfnc_nvnCommandBufferBindTransformFeedbackBuffer;
+extern nvnCommandBufferBindTransformFeedbackBuffersFunction
+    pfnc_nvnCommandBufferBindTransformFeedbackBuffers;
 extern nvnCommandBufferBindStorageBufferFunction pfnc_nvnCommandBufferBindStorageBuffer;
 extern nvnCommandBufferBindStorageBuffersFunction pfnc_nvnCommandBufferBindStorageBuffers;
 extern nvnCommandBufferBindTextureFunction pfnc_nvnCommandBufferBindTexture;
@@ -852,8 +1029,10 @@ extern nvnCommandBufferBindTexturesFunction pfnc_nvnCommandBufferBindTextures;
 extern nvnCommandBufferBindImageFunction pfnc_nvnCommandBufferBindImage;
 extern nvnCommandBufferBindImagesFunction pfnc_nvnCommandBufferBindImages;
 extern nvnCommandBufferSetPatchSizeFunction pfnc_nvnCommandBufferSetPatchSize;
-extern nvnCommandBufferSetInnerTessellationLevelsFunction pfnc_nvnCommandBufferSetInnerTessellationLevels;
-extern nvnCommandBufferSetOuterTessellationLevelsFunction pfnc_nvnCommandBufferSetOuterTessellationLevels;
+extern nvnCommandBufferSetInnerTessellationLevelsFunction
+    pfnc_nvnCommandBufferSetInnerTessellationLevels;
+extern nvnCommandBufferSetOuterTessellationLevelsFunction
+    pfnc_nvnCommandBufferSetOuterTessellationLevels;
 extern nvnCommandBufferSetPrimitiveRestartFunction pfnc_nvnCommandBufferSetPrimitiveRestart;
 extern nvnCommandBufferBeginTransformFeedbackFunction pfnc_nvnCommandBufferBeginTransformFeedback;
 extern nvnCommandBufferEndTransformFeedbackFunction pfnc_nvnCommandBufferEndTransformFeedback;
@@ -867,8 +1046,10 @@ extern nvnCommandBufferDrawArraysInstancedFunction pfnc_nvnCommandBufferDrawArra
 extern nvnCommandBufferDrawElementsInstancedFunction pfnc_nvnCommandBufferDrawElementsInstanced;
 extern nvnCommandBufferDrawArraysIndirectFunction pfnc_nvnCommandBufferDrawArraysIndirect;
 extern nvnCommandBufferDrawElementsIndirectFunction pfnc_nvnCommandBufferDrawElementsIndirect;
-extern nvnCommandBufferMultiDrawArraysIndirectCountFunction pfnc_nvnCommandBufferMultiDrawArraysIndirectCount;
-extern nvnCommandBufferMultiDrawElementsIndirectCountFunction pfnc_nvnCommandBufferMultiDrawElementsIndirectCount;
+extern nvnCommandBufferMultiDrawArraysIndirectCountFunction
+    pfnc_nvnCommandBufferMultiDrawArraysIndirectCount;
+extern nvnCommandBufferMultiDrawElementsIndirectCountFunction
+    pfnc_nvnCommandBufferMultiDrawElementsIndirectCount;
 extern nvnCommandBufferClearColorFunction pfnc_nvnCommandBufferClearColor;
 extern nvnCommandBufferClearColoriFunction pfnc_nvnCommandBufferClearColori;
 extern nvnCommandBufferClearColoruiFunction pfnc_nvnCommandBufferClearColorui;
@@ -900,9 +1081,12 @@ extern nvnCommandBufferSetAlphaRefFunction pfnc_nvnCommandBufferSetAlphaRef;
 extern nvnCommandBufferSetSampleMaskFunction pfnc_nvnCommandBufferSetSampleMask;
 extern nvnCommandBufferSetRasterizerDiscardFunction pfnc_nvnCommandBufferSetRasterizerDiscard;
 extern nvnCommandBufferSetDepthClampFunction pfnc_nvnCommandBufferSetDepthClamp;
-extern nvnCommandBufferSetConservativeRasterEnableFunction pfnc_nvnCommandBufferSetConservativeRasterEnable;
-extern nvnCommandBufferSetConservativeRasterDilateFunction pfnc_nvnCommandBufferSetConservativeRasterDilate;
-extern nvnCommandBufferSetSubpixelPrecisionBiasFunction pfnc_nvnCommandBufferSetSubpixelPrecisionBias;
+extern nvnCommandBufferSetConservativeRasterEnableFunction
+    pfnc_nvnCommandBufferSetConservativeRasterEnable;
+extern nvnCommandBufferSetConservativeRasterDilateFunction
+    pfnc_nvnCommandBufferSetConservativeRasterDilate;
+extern nvnCommandBufferSetSubpixelPrecisionBiasFunction
+    pfnc_nvnCommandBufferSetSubpixelPrecisionBias;
 extern nvnCommandBufferCopyBufferToTextureFunction pfnc_nvnCommandBufferCopyBufferToTexture;
 extern nvnCommandBufferCopyTextureToBufferFunction pfnc_nvnCommandBufferCopyTextureToBuffer;
 extern nvnCommandBufferCopyTextureToTextureFunction pfnc_nvnCommandBufferCopyTextureToTexture;
@@ -916,14 +1100,16 @@ extern nvnCommandBufferReportCounterFunction pfnc_nvnCommandBufferReportCounter;
 extern nvnCommandBufferResetCounterFunction pfnc_nvnCommandBufferResetCounter;
 extern nvnCommandBufferReportValueFunction pfnc_nvnCommandBufferReportValue;
 extern nvnCommandBufferSetRenderEnableFunction pfnc_nvnCommandBufferSetRenderEnable;
-extern nvnCommandBufferSetRenderEnableConditionalFunction pfnc_nvnCommandBufferSetRenderEnableConditional;
+extern nvnCommandBufferSetRenderEnableConditionalFunction
+    pfnc_nvnCommandBufferSetRenderEnableConditional;
 extern nvnCommandBufferSetRenderTargetsFunction pfnc_nvnCommandBufferSetRenderTargets;
 extern nvnCommandBufferDiscardColorFunction pfnc_nvnCommandBufferDiscardColor;
 extern nvnCommandBufferDiscardDepthStencilFunction pfnc_nvnCommandBufferDiscardDepthStencil;
 extern nvnCommandBufferDownsampleFunction pfnc_nvnCommandBufferDownsample;
 extern nvnCommandBufferTiledDownsampleFunction pfnc_nvnCommandBufferTiledDownsample;
 extern nvnCommandBufferDownsampleTextureViewFunction pfnc_nvnCommandBufferDownsampleTextureView;
-extern nvnCommandBufferTiledDownsampleTextureViewFunction pfnc_nvnCommandBufferTiledDownsampleTextureView;
+extern nvnCommandBufferTiledDownsampleTextureViewFunction
+    pfnc_nvnCommandBufferTiledDownsampleTextureView;
 extern nvnCommandBufferBarrierFunction pfnc_nvnCommandBufferBarrier;
 extern nvnCommandBufferWaitSyncFunction pfnc_nvnCommandBufferWaitSync;
 extern nvnCommandBufferFenceSyncFunction pfnc_nvnCommandBufferFenceSync;
@@ -939,7 +1125,8 @@ extern nvnCommandBufferGetCopyImageStrideFunction pfnc_nvnCommandBufferGetCopyIm
 extern nvnCommandBufferDrawTextureFunction pfnc_nvnCommandBufferDrawTexture;
 extern nvnProgramSetSubroutineLinkageFunction pfnc_nvnProgramSetSubroutineLinkage;
 extern nvnCommandBufferSetProgramSubroutinesFunction pfnc_nvnCommandBufferSetProgramSubroutines;
-extern nvnCommandBufferBindCoverageModulationTableFunction pfnc_nvnCommandBufferBindCoverageModulationTable;
+extern nvnCommandBufferBindCoverageModulationTableFunction
+    pfnc_nvnCommandBufferBindCoverageModulationTable;
 extern nvnCommandBufferResolveDepthBufferFunction pfnc_nvnCommandBufferResolveDepthBuffer;
 extern nvnCommandBufferPushDebugGroupStaticFunction pfnc_nvnCommandBufferPushDebugGroupStatic;
 extern nvnCommandBufferPushDebugGroupDynamicFunction pfnc_nvnCommandBufferPushDebugGroupDynamic;
@@ -947,7 +1134,8 @@ extern nvnCommandBufferPushDebugGroupFunction pfnc_nvnCommandBufferPushDebugGrou
 extern nvnCommandBufferPopDebugGroupFunction pfnc_nvnCommandBufferPopDebugGroup;
 extern nvnCommandBufferPopDebugGroupIdFunction pfnc_nvnCommandBufferPopDebugGroupId;
 extern nvnCommandBufferInsertDebugMarkerStaticFunction pfnc_nvnCommandBufferInsertDebugMarkerStatic;
-extern nvnCommandBufferInsertDebugMarkerDynamicFunction pfnc_nvnCommandBufferInsertDebugMarkerDynamic;
+extern nvnCommandBufferInsertDebugMarkerDynamicFunction
+    pfnc_nvnCommandBufferInsertDebugMarkerDynamic;
 extern nvnCommandBufferInsertDebugMarkerFunction pfnc_nvnCommandBufferInsertDebugMarker;
 extern nvnCommandBufferGetMemoryCallbackFunction pfnc_nvnCommandBufferGetMemoryCallback;
 extern nvnCommandBufferGetMemoryCallbackDataFunction pfnc_nvnCommandBufferGetMemoryCallbackData;
@@ -1248,8 +1436,10 @@ extern nvnCommandBufferSignalEventFunction pfnc_nvnCommandBufferSignalEvent;
 #define nvnMultisampleStateGetAlphaToCoverageDither pfnc_nvnMultisampleStateGetAlphaToCoverageDither
 #define nvnMultisampleStateSetRasterSamples pfnc_nvnMultisampleStateSetRasterSamples
 #define nvnMultisampleStateGetRasterSamples pfnc_nvnMultisampleStateGetRasterSamples
-#define nvnMultisampleStateSetCoverageModulationMode pfnc_nvnMultisampleStateSetCoverageModulationMode
-#define nvnMultisampleStateGetCoverageModulationMode pfnc_nvnMultisampleStateGetCoverageModulationMode
+#define nvnMultisampleStateSetCoverageModulationMode                                               \
+    pfnc_nvnMultisampleStateSetCoverageModulationMode
+#define nvnMultisampleStateGetCoverageModulationMode                                               \
+    pfnc_nvnMultisampleStateGetCoverageModulationMode
 #define nvnMultisampleStateSetCoverageToColorEnable pfnc_nvnMultisampleStateSetCoverageToColorEnable
 #define nvnMultisampleStateGetCoverageToColorEnable pfnc_nvnMultisampleStateGetCoverageToColorEnable
 #define nvnMultisampleStateSetCoverageToColorOutput pfnc_nvnMultisampleStateSetCoverageToColorOutput
@@ -1257,8 +1447,10 @@ extern nvnCommandBufferSignalEventFunction pfnc_nvnCommandBufferSignalEvent;
 #define nvnMultisampleStateSetSampleLocationsEnable pfnc_nvnMultisampleStateSetSampleLocationsEnable
 #define nvnMultisampleStateGetSampleLocationsEnable pfnc_nvnMultisampleStateGetSampleLocationsEnable
 #define nvnMultisampleStateGetSampleLocationsGrid pfnc_nvnMultisampleStateGetSampleLocationsGrid
-#define nvnMultisampleStateSetSampleLocationsGridEnable pfnc_nvnMultisampleStateSetSampleLocationsGridEnable
-#define nvnMultisampleStateGetSampleLocationsGridEnable pfnc_nvnMultisampleStateGetSampleLocationsGridEnable
+#define nvnMultisampleStateSetSampleLocationsGridEnable                                            \
+    pfnc_nvnMultisampleStateSetSampleLocationsGridEnable
+#define nvnMultisampleStateGetSampleLocationsGridEnable                                            \
+    pfnc_nvnMultisampleStateGetSampleLocationsGridEnable
 #define nvnMultisampleStateSetSampleLocations pfnc_nvnMultisampleStateSetSampleLocations
 #define nvnPolygonStateSetDefaults pfnc_nvnPolygonStateSetDefaults
 #define nvnPolygonStateSetCullFace pfnc_nvnPolygonStateSetCullFace
@@ -1323,7 +1515,8 @@ extern nvnCommandBufferSignalEventFunction pfnc_nvnCommandBufferSignalEvent;
 #define nvnCommandBufferBindUniformBuffer pfnc_nvnCommandBufferBindUniformBuffer
 #define nvnCommandBufferBindUniformBuffers pfnc_nvnCommandBufferBindUniformBuffers
 #define nvnCommandBufferBindTransformFeedbackBuffer pfnc_nvnCommandBufferBindTransformFeedbackBuffer
-#define nvnCommandBufferBindTransformFeedbackBuffers pfnc_nvnCommandBufferBindTransformFeedbackBuffers
+#define nvnCommandBufferBindTransformFeedbackBuffers                                               \
+    pfnc_nvnCommandBufferBindTransformFeedbackBuffers
 #define nvnCommandBufferBindStorageBuffer pfnc_nvnCommandBufferBindStorageBuffer
 #define nvnCommandBufferBindStorageBuffers pfnc_nvnCommandBufferBindStorageBuffers
 #define nvnCommandBufferBindTexture pfnc_nvnCommandBufferBindTexture
@@ -1346,8 +1539,10 @@ extern nvnCommandBufferSignalEventFunction pfnc_nvnCommandBufferSignalEvent;
 #define nvnCommandBufferDrawElementsInstanced pfnc_nvnCommandBufferDrawElementsInstanced
 #define nvnCommandBufferDrawArraysIndirect pfnc_nvnCommandBufferDrawArraysIndirect
 #define nvnCommandBufferDrawElementsIndirect pfnc_nvnCommandBufferDrawElementsIndirect
-#define nvnCommandBufferMultiDrawArraysIndirectCount pfnc_nvnCommandBufferMultiDrawArraysIndirectCount
-#define nvnCommandBufferMultiDrawElementsIndirectCount pfnc_nvnCommandBufferMultiDrawElementsIndirectCount
+#define nvnCommandBufferMultiDrawArraysIndirectCount                                               \
+    pfnc_nvnCommandBufferMultiDrawArraysIndirectCount
+#define nvnCommandBufferMultiDrawElementsIndirectCount                                             \
+    pfnc_nvnCommandBufferMultiDrawElementsIndirectCount
 #define nvnCommandBufferClearColor pfnc_nvnCommandBufferClearColor
 #define nvnCommandBufferClearColori pfnc_nvnCommandBufferClearColori
 #define nvnCommandBufferClearColorui pfnc_nvnCommandBufferClearColorui

--- a/include/nvn/nvn_types.h
+++ b/include/nvn/nvn_types.h
@@ -7,10 +7,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,7 +21,8 @@
  */
 
 // NVN types reconstructed from Darksiders II DWARF information.
-// NOTE: This only includes enums and structs used for NVN 53.105 but might contain more elements than expected (as Darksiders II uses a newer version of NVN).
+// NOTE: This only includes enums and structs used for NVN 53.105 but might contain more elements
+// than expected (as Darksiders II uses a newer version of NVN).
 // TODO: Include the extra information from the version used on Darksiders II for completeness.
 
 #pragma once
@@ -30,8 +31,8 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef uint64_t NVNtextureHandle;
 typedef uint64_t NVNimageHandle;

--- a/modules/nvn/nvnInit.cpp
+++ b/modules/nvn/nvnInit.cpp
@@ -1,483 +1,1194 @@
-#include "nvn/nvn.h"
+#include <nvn/nvn.h>
 
 extern "C" {
 void nvnLoadCProcs(const NVNdevice* device, nvnDeviceGetProcAddressFunction deviceGetProcAddress) {
-    pfnc_nvnDeviceBuilderSetDefaults = (nvnDeviceBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnDeviceBuilderSetDefaults");
-    pfnc_nvnDeviceBuilderSetFlags = (nvnDeviceBuilderSetFlagsFunction)deviceGetProcAddress(device, "nvnDeviceBuilderSetFlags");
-    pfnc_nvnDeviceInitialize = (nvnDeviceInitializeFunction)deviceGetProcAddress(device, "nvnDeviceInitialize");
-    pfnc_nvnDeviceFinalize = (nvnDeviceFinalizeFunction)deviceGetProcAddress(device, "nvnDeviceFinalize");
-    pfnc_nvnDeviceSetDebugLabel = (nvnDeviceSetDebugLabelFunction)deviceGetProcAddress(device, "nvnDeviceSetDebugLabel");
-    pfnc_nvnDeviceGetProcAddress = (nvnDeviceGetProcAddressFunction)deviceGetProcAddress(device, "nvnDeviceGetProcAddress");
-    pfnc_nvnDeviceGetInteger = (nvnDeviceGetIntegerFunction)deviceGetProcAddress(device, "nvnDeviceGetInteger");
-    pfnc_nvnDeviceGetCurrentTimestampInNanoseconds = (nvnDeviceGetCurrentTimestampInNanosecondsFunction)deviceGetProcAddress(device, "nvnDeviceGetCurrentTimestampInNanoseconds");
-    pfnc_nvnDeviceSetIntermediateShaderCache = (nvnDeviceSetIntermediateShaderCacheFunction)deviceGetProcAddress(device, "nvnDeviceSetIntermediateShaderCache");
-    pfnc_nvnDeviceGetTextureHandle = (nvnDeviceGetTextureHandleFunction)deviceGetProcAddress(device, "nvnDeviceGetTextureHandle");
-    pfnc_nvnDeviceGetTexelFetchHandle = (nvnDeviceGetTexelFetchHandleFunction)deviceGetProcAddress(device, "nvnDeviceGetTexelFetchHandle");
-    pfnc_nvnDeviceGetImageHandle = (nvnDeviceGetImageHandleFunction)deviceGetProcAddress(device, "nvnDeviceGetImageHandle");
-    pfnc_nvnDeviceInstallDebugCallback = (nvnDeviceInstallDebugCallbackFunction)deviceGetProcAddress(device, "nvnDeviceInstallDebugCallback");
-    pfnc_nvnDeviceGenerateDebugDomainId = (nvnDeviceGenerateDebugDomainIdFunction)deviceGetProcAddress(device, "nvnDeviceGenerateDebugDomainId");
-    pfnc_nvnDeviceSetWindowOriginMode = (nvnDeviceSetWindowOriginModeFunction)deviceGetProcAddress(device, "nvnDeviceSetWindowOriginMode");
-    pfnc_nvnDeviceSetDepthMode = (nvnDeviceSetDepthModeFunction)deviceGetProcAddress(device, "nvnDeviceSetDepthMode");
-    pfnc_nvnDeviceRegisterFastClearColor = (nvnDeviceRegisterFastClearColorFunction)deviceGetProcAddress(device, "nvnDeviceRegisterFastClearColor");
-    pfnc_nvnDeviceRegisterFastClearColori = (nvnDeviceRegisterFastClearColoriFunction)deviceGetProcAddress(device, "nvnDeviceRegisterFastClearColori");
-    pfnc_nvnDeviceRegisterFastClearColorui = (nvnDeviceRegisterFastClearColoruiFunction)deviceGetProcAddress(device, "nvnDeviceRegisterFastClearColorui");
-    pfnc_nvnDeviceRegisterFastClearDepth = (nvnDeviceRegisterFastClearDepthFunction)deviceGetProcAddress(device, "nvnDeviceRegisterFastClearDepth");
-    pfnc_nvnDeviceGetWindowOriginMode = (nvnDeviceGetWindowOriginModeFunction)deviceGetProcAddress(device, "nvnDeviceGetWindowOriginMode");
-    pfnc_nvnDeviceGetDepthMode = (nvnDeviceGetDepthModeFunction)deviceGetProcAddress(device, "nvnDeviceGetDepthMode");
-    pfnc_nvnDeviceGetTimestampInNanoseconds = (nvnDeviceGetTimestampInNanosecondsFunction)deviceGetProcAddress(device, "nvnDeviceGetTimestampInNanoseconds");
-    pfnc_nvnDeviceApplyDeferredFinalizes = (nvnDeviceApplyDeferredFinalizesFunction)deviceGetProcAddress(device, "nvnDeviceApplyDeferredFinalizes");
-    pfnc_nvnDeviceFinalizeCommandHandle = (nvnDeviceFinalizeCommandHandleFunction)deviceGetProcAddress(device, "nvnDeviceFinalizeCommandHandle");
-    pfnc_nvnDeviceWalkDebugDatabase = (nvnDeviceWalkDebugDatabaseFunction)deviceGetProcAddress(device, "nvnDeviceWalkDebugDatabase");
-    pfnc_nvnDeviceGetSeparateTextureHandle = (nvnDeviceGetSeparateTextureHandleFunction)deviceGetProcAddress(device, "nvnDeviceGetSeparateTextureHandle");
-    pfnc_nvnDeviceGetSeparateSamplerHandle = (nvnDeviceGetSeparateSamplerHandleFunction)deviceGetProcAddress(device, "nvnDeviceGetSeparateSamplerHandle");
-    pfnc_nvnDeviceIsExternalDebuggerAttached = (nvnDeviceIsExternalDebuggerAttachedFunction)deviceGetProcAddress(device, "nvnDeviceIsExternalDebuggerAttached");
-    pfnc_nvnQueueGetError = (nvnQueueGetErrorFunction)deviceGetProcAddress(device, "nvnQueueGetError");
-    pfnc_nvnQueueGetTotalCommandMemoryUsed = (nvnQueueGetTotalCommandMemoryUsedFunction)deviceGetProcAddress(device, "nvnQueueGetTotalCommandMemoryUsed");
-    pfnc_nvnQueueGetTotalControlMemoryUsed = (nvnQueueGetTotalControlMemoryUsedFunction)deviceGetProcAddress(device, "nvnQueueGetTotalControlMemoryUsed");
-    pfnc_nvnQueueGetTotalComputeMemoryUsed = (nvnQueueGetTotalComputeMemoryUsedFunction)deviceGetProcAddress(device, "nvnQueueGetTotalComputeMemoryUsed");
-    pfnc_nvnQueueResetMemoryUsageCounts = (nvnQueueResetMemoryUsageCountsFunction)deviceGetProcAddress(device, "nvnQueueResetMemoryUsageCounts");
-    pfnc_nvnQueueBuilderSetDevice = (nvnQueueBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetDevice");
-    pfnc_nvnQueueBuilderSetDefaults = (nvnQueueBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetDefaults");
-    pfnc_nvnQueueBuilderSetFlags = (nvnQueueBuilderSetFlagsFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetFlags");
-    pfnc_nvnQueueBuilderSetCommandMemorySize = (nvnQueueBuilderSetCommandMemorySizeFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetCommandMemorySize");
-    pfnc_nvnQueueBuilderSetComputeMemorySize = (nvnQueueBuilderSetComputeMemorySizeFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetComputeMemorySize");
-    pfnc_nvnQueueBuilderSetControlMemorySize = (nvnQueueBuilderSetControlMemorySizeFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetControlMemorySize");
-    pfnc_nvnQueueBuilderGetQueueMemorySize = (nvnQueueBuilderGetQueueMemorySizeFunction)deviceGetProcAddress(device, "nvnQueueBuilderGetQueueMemorySize");
-    pfnc_nvnQueueBuilderSetQueueMemory = (nvnQueueBuilderSetQueueMemoryFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetQueueMemory");
-    pfnc_nvnQueueBuilderSetCommandFlushThreshold = (nvnQueueBuilderSetCommandFlushThresholdFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetCommandFlushThreshold");
-    pfnc_nvnQueueInitialize = (nvnQueueInitializeFunction)deviceGetProcAddress(device, "nvnQueueInitialize");
-    pfnc_nvnQueueFinalize = (nvnQueueFinalizeFunction)deviceGetProcAddress(device, "nvnQueueFinalize");
-    pfnc_nvnQueueSetDebugLabel = (nvnQueueSetDebugLabelFunction)deviceGetProcAddress(device, "nvnQueueSetDebugLabel");
-    pfnc_nvnQueueSubmitCommands = (nvnQueueSubmitCommandsFunction)deviceGetProcAddress(device, "nvnQueueSubmitCommands");
+    pfnc_nvnDeviceBuilderSetDefaults = (nvnDeviceBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnDeviceBuilderSetDefaults");
+    pfnc_nvnDeviceBuilderSetFlags =
+        (nvnDeviceBuilderSetFlagsFunction)deviceGetProcAddress(device, "nvnDeviceBuilderSetFlags");
+    pfnc_nvnDeviceInitialize =
+        (nvnDeviceInitializeFunction)deviceGetProcAddress(device, "nvnDeviceInitialize");
+    pfnc_nvnDeviceFinalize =
+        (nvnDeviceFinalizeFunction)deviceGetProcAddress(device, "nvnDeviceFinalize");
+    pfnc_nvnDeviceSetDebugLabel =
+        (nvnDeviceSetDebugLabelFunction)deviceGetProcAddress(device, "nvnDeviceSetDebugLabel");
+    pfnc_nvnDeviceGetProcAddress =
+        (nvnDeviceGetProcAddressFunction)deviceGetProcAddress(device, "nvnDeviceGetProcAddress");
+    pfnc_nvnDeviceGetInteger =
+        (nvnDeviceGetIntegerFunction)deviceGetProcAddress(device, "nvnDeviceGetInteger");
+    pfnc_nvnDeviceGetCurrentTimestampInNanoseconds =
+        (nvnDeviceGetCurrentTimestampInNanosecondsFunction)deviceGetProcAddress(
+            device, "nvnDeviceGetCurrentTimestampInNanoseconds");
+    pfnc_nvnDeviceSetIntermediateShaderCache =
+        (nvnDeviceSetIntermediateShaderCacheFunction)deviceGetProcAddress(
+            device, "nvnDeviceSetIntermediateShaderCache");
+    pfnc_nvnDeviceGetTextureHandle = (nvnDeviceGetTextureHandleFunction)deviceGetProcAddress(
+        device, "nvnDeviceGetTextureHandle");
+    pfnc_nvnDeviceGetTexelFetchHandle = (nvnDeviceGetTexelFetchHandleFunction)deviceGetProcAddress(
+        device, "nvnDeviceGetTexelFetchHandle");
+    pfnc_nvnDeviceGetImageHandle =
+        (nvnDeviceGetImageHandleFunction)deviceGetProcAddress(device, "nvnDeviceGetImageHandle");
+    pfnc_nvnDeviceInstallDebugCallback =
+        (nvnDeviceInstallDebugCallbackFunction)deviceGetProcAddress(
+            device, "nvnDeviceInstallDebugCallback");
+    pfnc_nvnDeviceGenerateDebugDomainId =
+        (nvnDeviceGenerateDebugDomainIdFunction)deviceGetProcAddress(
+            device, "nvnDeviceGenerateDebugDomainId");
+    pfnc_nvnDeviceSetWindowOriginMode = (nvnDeviceSetWindowOriginModeFunction)deviceGetProcAddress(
+        device, "nvnDeviceSetWindowOriginMode");
+    pfnc_nvnDeviceSetDepthMode =
+        (nvnDeviceSetDepthModeFunction)deviceGetProcAddress(device, "nvnDeviceSetDepthMode");
+    pfnc_nvnDeviceRegisterFastClearColor =
+        (nvnDeviceRegisterFastClearColorFunction)deviceGetProcAddress(
+            device, "nvnDeviceRegisterFastClearColor");
+    pfnc_nvnDeviceRegisterFastClearColori =
+        (nvnDeviceRegisterFastClearColoriFunction)deviceGetProcAddress(
+            device, "nvnDeviceRegisterFastClearColori");
+    pfnc_nvnDeviceRegisterFastClearColorui =
+        (nvnDeviceRegisterFastClearColoruiFunction)deviceGetProcAddress(
+            device, "nvnDeviceRegisterFastClearColorui");
+    pfnc_nvnDeviceRegisterFastClearDepth =
+        (nvnDeviceRegisterFastClearDepthFunction)deviceGetProcAddress(
+            device, "nvnDeviceRegisterFastClearDepth");
+    pfnc_nvnDeviceGetWindowOriginMode = (nvnDeviceGetWindowOriginModeFunction)deviceGetProcAddress(
+        device, "nvnDeviceGetWindowOriginMode");
+    pfnc_nvnDeviceGetDepthMode =
+        (nvnDeviceGetDepthModeFunction)deviceGetProcAddress(device, "nvnDeviceGetDepthMode");
+    pfnc_nvnDeviceGetTimestampInNanoseconds =
+        (nvnDeviceGetTimestampInNanosecondsFunction)deviceGetProcAddress(
+            device, "nvnDeviceGetTimestampInNanoseconds");
+    pfnc_nvnDeviceApplyDeferredFinalizes =
+        (nvnDeviceApplyDeferredFinalizesFunction)deviceGetProcAddress(
+            device, "nvnDeviceApplyDeferredFinalizes");
+    pfnc_nvnDeviceFinalizeCommandHandle =
+        (nvnDeviceFinalizeCommandHandleFunction)deviceGetProcAddress(
+            device, "nvnDeviceFinalizeCommandHandle");
+    pfnc_nvnDeviceWalkDebugDatabase = (nvnDeviceWalkDebugDatabaseFunction)deviceGetProcAddress(
+        device, "nvnDeviceWalkDebugDatabase");
+    pfnc_nvnDeviceGetSeparateTextureHandle =
+        (nvnDeviceGetSeparateTextureHandleFunction)deviceGetProcAddress(
+            device, "nvnDeviceGetSeparateTextureHandle");
+    pfnc_nvnDeviceGetSeparateSamplerHandle =
+        (nvnDeviceGetSeparateSamplerHandleFunction)deviceGetProcAddress(
+            device, "nvnDeviceGetSeparateSamplerHandle");
+    pfnc_nvnDeviceIsExternalDebuggerAttached =
+        (nvnDeviceIsExternalDebuggerAttachedFunction)deviceGetProcAddress(
+            device, "nvnDeviceIsExternalDebuggerAttached");
+    pfnc_nvnQueueGetError =
+        (nvnQueueGetErrorFunction)deviceGetProcAddress(device, "nvnQueueGetError");
+    pfnc_nvnQueueGetTotalCommandMemoryUsed =
+        (nvnQueueGetTotalCommandMemoryUsedFunction)deviceGetProcAddress(
+            device, "nvnQueueGetTotalCommandMemoryUsed");
+    pfnc_nvnQueueGetTotalControlMemoryUsed =
+        (nvnQueueGetTotalControlMemoryUsedFunction)deviceGetProcAddress(
+            device, "nvnQueueGetTotalControlMemoryUsed");
+    pfnc_nvnQueueGetTotalComputeMemoryUsed =
+        (nvnQueueGetTotalComputeMemoryUsedFunction)deviceGetProcAddress(
+            device, "nvnQueueGetTotalComputeMemoryUsed");
+    pfnc_nvnQueueResetMemoryUsageCounts =
+        (nvnQueueResetMemoryUsageCountsFunction)deviceGetProcAddress(
+            device, "nvnQueueResetMemoryUsageCounts");
+    pfnc_nvnQueueBuilderSetDevice =
+        (nvnQueueBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetDevice");
+    pfnc_nvnQueueBuilderSetDefaults = (nvnQueueBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnQueueBuilderSetDefaults");
+    pfnc_nvnQueueBuilderSetFlags =
+        (nvnQueueBuilderSetFlagsFunction)deviceGetProcAddress(device, "nvnQueueBuilderSetFlags");
+    pfnc_nvnQueueBuilderSetCommandMemorySize =
+        (nvnQueueBuilderSetCommandMemorySizeFunction)deviceGetProcAddress(
+            device, "nvnQueueBuilderSetCommandMemorySize");
+    pfnc_nvnQueueBuilderSetComputeMemorySize =
+        (nvnQueueBuilderSetComputeMemorySizeFunction)deviceGetProcAddress(
+            device, "nvnQueueBuilderSetComputeMemorySize");
+    pfnc_nvnQueueBuilderSetControlMemorySize =
+        (nvnQueueBuilderSetControlMemorySizeFunction)deviceGetProcAddress(
+            device, "nvnQueueBuilderSetControlMemorySize");
+    pfnc_nvnQueueBuilderGetQueueMemorySize =
+        (nvnQueueBuilderGetQueueMemorySizeFunction)deviceGetProcAddress(
+            device, "nvnQueueBuilderGetQueueMemorySize");
+    pfnc_nvnQueueBuilderSetQueueMemory =
+        (nvnQueueBuilderSetQueueMemoryFunction)deviceGetProcAddress(
+            device, "nvnQueueBuilderSetQueueMemory");
+    pfnc_nvnQueueBuilderSetCommandFlushThreshold =
+        (nvnQueueBuilderSetCommandFlushThresholdFunction)deviceGetProcAddress(
+            device, "nvnQueueBuilderSetCommandFlushThreshold");
+    pfnc_nvnQueueInitialize =
+        (nvnQueueInitializeFunction)deviceGetProcAddress(device, "nvnQueueInitialize");
+    pfnc_nvnQueueFinalize =
+        (nvnQueueFinalizeFunction)deviceGetProcAddress(device, "nvnQueueFinalize");
+    pfnc_nvnQueueSetDebugLabel =
+        (nvnQueueSetDebugLabelFunction)deviceGetProcAddress(device, "nvnQueueSetDebugLabel");
+    pfnc_nvnQueueSubmitCommands =
+        (nvnQueueSubmitCommandsFunction)deviceGetProcAddress(device, "nvnQueueSubmitCommands");
     pfnc_nvnQueueFlush = (nvnQueueFlushFunction)deviceGetProcAddress(device, "nvnQueueFlush");
     pfnc_nvnQueueFinish = (nvnQueueFinishFunction)deviceGetProcAddress(device, "nvnQueueFinish");
-    pfnc_nvnQueuePresentTexture = (nvnQueuePresentTextureFunction)deviceGetProcAddress(device, "nvnQueuePresentTexture");
-    pfnc_nvnQueueAcquireTexture = (nvnQueueAcquireTextureFunction)deviceGetProcAddress(device, "nvnQueueAcquireTexture");
-    pfnc_nvnWindowBuilderSetDevice = (nvnWindowBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnWindowBuilderSetDevice");
-    pfnc_nvnWindowBuilderSetDefaults = (nvnWindowBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnWindowBuilderSetDefaults");
-    pfnc_nvnWindowBuilderSetNativeWindow = (nvnWindowBuilderSetNativeWindowFunction)deviceGetProcAddress(device, "nvnWindowBuilderSetNativeWindow");
-    pfnc_nvnWindowBuilderSetTextures = (nvnWindowBuilderSetTexturesFunction)deviceGetProcAddress(device, "nvnWindowBuilderSetTextures");
-    pfnc_nvnWindowBuilderSetPresentInterval = (nvnWindowBuilderSetPresentIntervalFunction)deviceGetProcAddress(device, "nvnWindowBuilderSetPresentInterval");
-    pfnc_nvnWindowBuilderGetNativeWindow = (nvnWindowBuilderGetNativeWindowFunction)deviceGetProcAddress(device, "nvnWindowBuilderGetNativeWindow");
-    pfnc_nvnWindowBuilderGetPresentInterval = (nvnWindowBuilderGetPresentIntervalFunction)deviceGetProcAddress(device, "nvnWindowBuilderGetPresentInterval");
-    pfnc_nvnWindowInitialize = (nvnWindowInitializeFunction)deviceGetProcAddress(device, "nvnWindowInitialize");
-    pfnc_nvnWindowFinalize = (nvnWindowFinalizeFunction)deviceGetProcAddress(device, "nvnWindowFinalize");
-    pfnc_nvnWindowSetDebugLabel = (nvnWindowSetDebugLabelFunction)deviceGetProcAddress(device, "nvnWindowSetDebugLabel");
-    pfnc_nvnWindowAcquireTexture = (nvnWindowAcquireTextureFunction)deviceGetProcAddress(device, "nvnWindowAcquireTexture");
-    pfnc_nvnWindowGetNativeWindow = (nvnWindowGetNativeWindowFunction)deviceGetProcAddress(device, "nvnWindowGetNativeWindow");
-    pfnc_nvnWindowGetPresentInterval = (nvnWindowGetPresentIntervalFunction)deviceGetProcAddress(device, "nvnWindowGetPresentInterval");
-    pfnc_nvnWindowSetPresentInterval = (nvnWindowSetPresentIntervalFunction)deviceGetProcAddress(device, "nvnWindowSetPresentInterval");
-    pfnc_nvnWindowSetCrop = (nvnWindowSetCropFunction)deviceGetProcAddress(device, "nvnWindowSetCrop");
-    pfnc_nvnWindowGetCrop = (nvnWindowGetCropFunction)deviceGetProcAddress(device, "nvnWindowGetCrop");
-    pfnc_nvnProgramInitialize = (nvnProgramInitializeFunction)deviceGetProcAddress(device, "nvnProgramInitialize");
-    pfnc_nvnProgramFinalize = (nvnProgramFinalizeFunction)deviceGetProcAddress(device, "nvnProgramFinalize");
-    pfnc_nvnProgramSetDebugLabel = (nvnProgramSetDebugLabelFunction)deviceGetProcAddress(device, "nvnProgramSetDebugLabel");
-    pfnc_nvnProgramSetShaders = (nvnProgramSetShadersFunction)deviceGetProcAddress(device, "nvnProgramSetShaders");
-    pfnc_nvnMemoryPoolBuilderSetDevice = (nvnMemoryPoolBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderSetDevice");
-    pfnc_nvnMemoryPoolBuilderSetDefaults = (nvnMemoryPoolBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderSetDefaults");
-    pfnc_nvnMemoryPoolBuilderSetStorage = (nvnMemoryPoolBuilderSetStorageFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderSetStorage");
-    pfnc_nvnMemoryPoolBuilderSetFlags = (nvnMemoryPoolBuilderSetFlagsFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderSetFlags");
-    pfnc_nvnMemoryPoolBuilderGetMemory = (nvnMemoryPoolBuilderGetMemoryFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderGetMemory");
-    pfnc_nvnMemoryPoolBuilderGetSize = (nvnMemoryPoolBuilderGetSizeFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderGetSize");
-    pfnc_nvnMemoryPoolBuilderGetFlags = (nvnMemoryPoolBuilderGetFlagsFunction)deviceGetProcAddress(device, "nvnMemoryPoolBuilderGetFlags");
-    pfnc_nvnMemoryPoolInitialize = (nvnMemoryPoolInitializeFunction)deviceGetProcAddress(device, "nvnMemoryPoolInitialize");
-    pfnc_nvnMemoryPoolSetDebugLabel = (nvnMemoryPoolSetDebugLabelFunction)deviceGetProcAddress(device, "nvnMemoryPoolSetDebugLabel");
-    pfnc_nvnMemoryPoolFinalize = (nvnMemoryPoolFinalizeFunction)deviceGetProcAddress(device, "nvnMemoryPoolFinalize");
-    pfnc_nvnMemoryPoolMap = (nvnMemoryPoolMapFunction)deviceGetProcAddress(device, "nvnMemoryPoolMap");
-    pfnc_nvnMemoryPoolFlushMappedRange = (nvnMemoryPoolFlushMappedRangeFunction)deviceGetProcAddress(device, "nvnMemoryPoolFlushMappedRange");
-    pfnc_nvnMemoryPoolInvalidateMappedRange = (nvnMemoryPoolInvalidateMappedRangeFunction)deviceGetProcAddress(device, "nvnMemoryPoolInvalidateMappedRange");
-    pfnc_nvnMemoryPoolGetBufferAddress = (nvnMemoryPoolGetBufferAddressFunction)deviceGetProcAddress(device, "nvnMemoryPoolGetBufferAddress");
-    pfnc_nvnMemoryPoolMapVirtual = (nvnMemoryPoolMapVirtualFunction)deviceGetProcAddress(device, "nvnMemoryPoolMapVirtual");
-    pfnc_nvnMemoryPoolGetSize = (nvnMemoryPoolGetSizeFunction)deviceGetProcAddress(device, "nvnMemoryPoolGetSize");
-    pfnc_nvnMemoryPoolGetFlags = (nvnMemoryPoolGetFlagsFunction)deviceGetProcAddress(device, "nvnMemoryPoolGetFlags");
-    pfnc_nvnTexturePoolInitialize = (nvnTexturePoolInitializeFunction)deviceGetProcAddress(device, "nvnTexturePoolInitialize");
-    pfnc_nvnTexturePoolSetDebugLabel = (nvnTexturePoolSetDebugLabelFunction)deviceGetProcAddress(device, "nvnTexturePoolSetDebugLabel");
-    pfnc_nvnTexturePoolFinalize = (nvnTexturePoolFinalizeFunction)deviceGetProcAddress(device, "nvnTexturePoolFinalize");
-    pfnc_nvnTexturePoolRegisterTexture = (nvnTexturePoolRegisterTextureFunction)deviceGetProcAddress(device, "nvnTexturePoolRegisterTexture");
-    pfnc_nvnTexturePoolRegisterImage = (nvnTexturePoolRegisterImageFunction)deviceGetProcAddress(device, "nvnTexturePoolRegisterImage");
-    pfnc_nvnTexturePoolGetMemoryPool = (nvnTexturePoolGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnTexturePoolGetMemoryPool");
-    pfnc_nvnTexturePoolGetMemoryOffset = (nvnTexturePoolGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnTexturePoolGetMemoryOffset");
-    pfnc_nvnTexturePoolGetSize = (nvnTexturePoolGetSizeFunction)deviceGetProcAddress(device, "nvnTexturePoolGetSize");
-    pfnc_nvnSamplerPoolInitialize = (nvnSamplerPoolInitializeFunction)deviceGetProcAddress(device, "nvnSamplerPoolInitialize");
-    pfnc_nvnSamplerPoolSetDebugLabel = (nvnSamplerPoolSetDebugLabelFunction)deviceGetProcAddress(device, "nvnSamplerPoolSetDebugLabel");
-    pfnc_nvnSamplerPoolFinalize = (nvnSamplerPoolFinalizeFunction)deviceGetProcAddress(device, "nvnSamplerPoolFinalize");
-    pfnc_nvnSamplerPoolRegisterSampler = (nvnSamplerPoolRegisterSamplerFunction)deviceGetProcAddress(device, "nvnSamplerPoolRegisterSampler");
-    pfnc_nvnSamplerPoolRegisterSamplerBuilder = (nvnSamplerPoolRegisterSamplerBuilderFunction)deviceGetProcAddress(device, "nvnSamplerPoolRegisterSamplerBuilder");
-    pfnc_nvnSamplerPoolGetMemoryPool = (nvnSamplerPoolGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnSamplerPoolGetMemoryPool");
-    pfnc_nvnSamplerPoolGetMemoryOffset = (nvnSamplerPoolGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnSamplerPoolGetMemoryOffset");
-    pfnc_nvnSamplerPoolGetSize = (nvnSamplerPoolGetSizeFunction)deviceGetProcAddress(device, "nvnSamplerPoolGetSize");
-    pfnc_nvnBufferBuilderSetDevice = (nvnBufferBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnBufferBuilderSetDevice");
-    pfnc_nvnBufferBuilderSetDefaults = (nvnBufferBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnBufferBuilderSetDefaults");
-    pfnc_nvnBufferBuilderSetStorage = (nvnBufferBuilderSetStorageFunction)deviceGetProcAddress(device, "nvnBufferBuilderSetStorage");
-    pfnc_nvnBufferBuilderGetMemoryPool = (nvnBufferBuilderGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnBufferBuilderGetMemoryPool");
-    pfnc_nvnBufferBuilderGetMemoryOffset = (nvnBufferBuilderGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnBufferBuilderGetMemoryOffset");
-    pfnc_nvnBufferBuilderGetSize = (nvnBufferBuilderGetSizeFunction)deviceGetProcAddress(device, "nvnBufferBuilderGetSize");
-    pfnc_nvnBufferInitialize = (nvnBufferInitializeFunction)deviceGetProcAddress(device, "nvnBufferInitialize");
-    pfnc_nvnBufferSetDebugLabel = (nvnBufferSetDebugLabelFunction)deviceGetProcAddress(device, "nvnBufferSetDebugLabel");
-    pfnc_nvnBufferFinalize = (nvnBufferFinalizeFunction)deviceGetProcAddress(device, "nvnBufferFinalize");
+    pfnc_nvnQueuePresentTexture =
+        (nvnQueuePresentTextureFunction)deviceGetProcAddress(device, "nvnQueuePresentTexture");
+    pfnc_nvnQueueAcquireTexture =
+        (nvnQueueAcquireTextureFunction)deviceGetProcAddress(device, "nvnQueueAcquireTexture");
+    pfnc_nvnWindowBuilderSetDevice = (nvnWindowBuilderSetDeviceFunction)deviceGetProcAddress(
+        device, "nvnWindowBuilderSetDevice");
+    pfnc_nvnWindowBuilderSetDefaults = (nvnWindowBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnWindowBuilderSetDefaults");
+    pfnc_nvnWindowBuilderSetNativeWindow =
+        (nvnWindowBuilderSetNativeWindowFunction)deviceGetProcAddress(
+            device, "nvnWindowBuilderSetNativeWindow");
+    pfnc_nvnWindowBuilderSetTextures = (nvnWindowBuilderSetTexturesFunction)deviceGetProcAddress(
+        device, "nvnWindowBuilderSetTextures");
+    pfnc_nvnWindowBuilderSetPresentInterval =
+        (nvnWindowBuilderSetPresentIntervalFunction)deviceGetProcAddress(
+            device, "nvnWindowBuilderSetPresentInterval");
+    pfnc_nvnWindowBuilderGetNativeWindow =
+        (nvnWindowBuilderGetNativeWindowFunction)deviceGetProcAddress(
+            device, "nvnWindowBuilderGetNativeWindow");
+    pfnc_nvnWindowBuilderGetPresentInterval =
+        (nvnWindowBuilderGetPresentIntervalFunction)deviceGetProcAddress(
+            device, "nvnWindowBuilderGetPresentInterval");
+    pfnc_nvnWindowInitialize =
+        (nvnWindowInitializeFunction)deviceGetProcAddress(device, "nvnWindowInitialize");
+    pfnc_nvnWindowFinalize =
+        (nvnWindowFinalizeFunction)deviceGetProcAddress(device, "nvnWindowFinalize");
+    pfnc_nvnWindowSetDebugLabel =
+        (nvnWindowSetDebugLabelFunction)deviceGetProcAddress(device, "nvnWindowSetDebugLabel");
+    pfnc_nvnWindowAcquireTexture =
+        (nvnWindowAcquireTextureFunction)deviceGetProcAddress(device, "nvnWindowAcquireTexture");
+    pfnc_nvnWindowGetNativeWindow =
+        (nvnWindowGetNativeWindowFunction)deviceGetProcAddress(device, "nvnWindowGetNativeWindow");
+    pfnc_nvnWindowGetPresentInterval = (nvnWindowGetPresentIntervalFunction)deviceGetProcAddress(
+        device, "nvnWindowGetPresentInterval");
+    pfnc_nvnWindowSetPresentInterval = (nvnWindowSetPresentIntervalFunction)deviceGetProcAddress(
+        device, "nvnWindowSetPresentInterval");
+    pfnc_nvnWindowSetCrop =
+        (nvnWindowSetCropFunction)deviceGetProcAddress(device, "nvnWindowSetCrop");
+    pfnc_nvnWindowGetCrop =
+        (nvnWindowGetCropFunction)deviceGetProcAddress(device, "nvnWindowGetCrop");
+    pfnc_nvnProgramInitialize =
+        (nvnProgramInitializeFunction)deviceGetProcAddress(device, "nvnProgramInitialize");
+    pfnc_nvnProgramFinalize =
+        (nvnProgramFinalizeFunction)deviceGetProcAddress(device, "nvnProgramFinalize");
+    pfnc_nvnProgramSetDebugLabel =
+        (nvnProgramSetDebugLabelFunction)deviceGetProcAddress(device, "nvnProgramSetDebugLabel");
+    pfnc_nvnProgramSetShaders =
+        (nvnProgramSetShadersFunction)deviceGetProcAddress(device, "nvnProgramSetShaders");
+    pfnc_nvnMemoryPoolBuilderSetDevice =
+        (nvnMemoryPoolBuilderSetDeviceFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolBuilderSetDevice");
+    pfnc_nvnMemoryPoolBuilderSetDefaults =
+        (nvnMemoryPoolBuilderSetDefaultsFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolBuilderSetDefaults");
+    pfnc_nvnMemoryPoolBuilderSetStorage =
+        (nvnMemoryPoolBuilderSetStorageFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolBuilderSetStorage");
+    pfnc_nvnMemoryPoolBuilderSetFlags = (nvnMemoryPoolBuilderSetFlagsFunction)deviceGetProcAddress(
+        device, "nvnMemoryPoolBuilderSetFlags");
+    pfnc_nvnMemoryPoolBuilderGetMemory =
+        (nvnMemoryPoolBuilderGetMemoryFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolBuilderGetMemory");
+    pfnc_nvnMemoryPoolBuilderGetSize = (nvnMemoryPoolBuilderGetSizeFunction)deviceGetProcAddress(
+        device, "nvnMemoryPoolBuilderGetSize");
+    pfnc_nvnMemoryPoolBuilderGetFlags = (nvnMemoryPoolBuilderGetFlagsFunction)deviceGetProcAddress(
+        device, "nvnMemoryPoolBuilderGetFlags");
+    pfnc_nvnMemoryPoolInitialize =
+        (nvnMemoryPoolInitializeFunction)deviceGetProcAddress(device, "nvnMemoryPoolInitialize");
+    pfnc_nvnMemoryPoolSetDebugLabel = (nvnMemoryPoolSetDebugLabelFunction)deviceGetProcAddress(
+        device, "nvnMemoryPoolSetDebugLabel");
+    pfnc_nvnMemoryPoolFinalize =
+        (nvnMemoryPoolFinalizeFunction)deviceGetProcAddress(device, "nvnMemoryPoolFinalize");
+    pfnc_nvnMemoryPoolMap =
+        (nvnMemoryPoolMapFunction)deviceGetProcAddress(device, "nvnMemoryPoolMap");
+    pfnc_nvnMemoryPoolFlushMappedRange =
+        (nvnMemoryPoolFlushMappedRangeFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolFlushMappedRange");
+    pfnc_nvnMemoryPoolInvalidateMappedRange =
+        (nvnMemoryPoolInvalidateMappedRangeFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolInvalidateMappedRange");
+    pfnc_nvnMemoryPoolGetBufferAddress =
+        (nvnMemoryPoolGetBufferAddressFunction)deviceGetProcAddress(
+            device, "nvnMemoryPoolGetBufferAddress");
+    pfnc_nvnMemoryPoolMapVirtual =
+        (nvnMemoryPoolMapVirtualFunction)deviceGetProcAddress(device, "nvnMemoryPoolMapVirtual");
+    pfnc_nvnMemoryPoolGetSize =
+        (nvnMemoryPoolGetSizeFunction)deviceGetProcAddress(device, "nvnMemoryPoolGetSize");
+    pfnc_nvnMemoryPoolGetFlags =
+        (nvnMemoryPoolGetFlagsFunction)deviceGetProcAddress(device, "nvnMemoryPoolGetFlags");
+    pfnc_nvnTexturePoolInitialize =
+        (nvnTexturePoolInitializeFunction)deviceGetProcAddress(device, "nvnTexturePoolInitialize");
+    pfnc_nvnTexturePoolSetDebugLabel = (nvnTexturePoolSetDebugLabelFunction)deviceGetProcAddress(
+        device, "nvnTexturePoolSetDebugLabel");
+    pfnc_nvnTexturePoolFinalize =
+        (nvnTexturePoolFinalizeFunction)deviceGetProcAddress(device, "nvnTexturePoolFinalize");
+    pfnc_nvnTexturePoolRegisterTexture =
+        (nvnTexturePoolRegisterTextureFunction)deviceGetProcAddress(
+            device, "nvnTexturePoolRegisterTexture");
+    pfnc_nvnTexturePoolRegisterImage = (nvnTexturePoolRegisterImageFunction)deviceGetProcAddress(
+        device, "nvnTexturePoolRegisterImage");
+    pfnc_nvnTexturePoolGetMemoryPool = (nvnTexturePoolGetMemoryPoolFunction)deviceGetProcAddress(
+        device, "nvnTexturePoolGetMemoryPool");
+    pfnc_nvnTexturePoolGetMemoryOffset =
+        (nvnTexturePoolGetMemoryOffsetFunction)deviceGetProcAddress(
+            device, "nvnTexturePoolGetMemoryOffset");
+    pfnc_nvnTexturePoolGetSize =
+        (nvnTexturePoolGetSizeFunction)deviceGetProcAddress(device, "nvnTexturePoolGetSize");
+    pfnc_nvnSamplerPoolInitialize =
+        (nvnSamplerPoolInitializeFunction)deviceGetProcAddress(device, "nvnSamplerPoolInitialize");
+    pfnc_nvnSamplerPoolSetDebugLabel = (nvnSamplerPoolSetDebugLabelFunction)deviceGetProcAddress(
+        device, "nvnSamplerPoolSetDebugLabel");
+    pfnc_nvnSamplerPoolFinalize =
+        (nvnSamplerPoolFinalizeFunction)deviceGetProcAddress(device, "nvnSamplerPoolFinalize");
+    pfnc_nvnSamplerPoolRegisterSampler =
+        (nvnSamplerPoolRegisterSamplerFunction)deviceGetProcAddress(
+            device, "nvnSamplerPoolRegisterSampler");
+    pfnc_nvnSamplerPoolRegisterSamplerBuilder =
+        (nvnSamplerPoolRegisterSamplerBuilderFunction)deviceGetProcAddress(
+            device, "nvnSamplerPoolRegisterSamplerBuilder");
+    pfnc_nvnSamplerPoolGetMemoryPool = (nvnSamplerPoolGetMemoryPoolFunction)deviceGetProcAddress(
+        device, "nvnSamplerPoolGetMemoryPool");
+    pfnc_nvnSamplerPoolGetMemoryOffset =
+        (nvnSamplerPoolGetMemoryOffsetFunction)deviceGetProcAddress(
+            device, "nvnSamplerPoolGetMemoryOffset");
+    pfnc_nvnSamplerPoolGetSize =
+        (nvnSamplerPoolGetSizeFunction)deviceGetProcAddress(device, "nvnSamplerPoolGetSize");
+    pfnc_nvnBufferBuilderSetDevice = (nvnBufferBuilderSetDeviceFunction)deviceGetProcAddress(
+        device, "nvnBufferBuilderSetDevice");
+    pfnc_nvnBufferBuilderSetDefaults = (nvnBufferBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnBufferBuilderSetDefaults");
+    pfnc_nvnBufferBuilderSetStorage = (nvnBufferBuilderSetStorageFunction)deviceGetProcAddress(
+        device, "nvnBufferBuilderSetStorage");
+    pfnc_nvnBufferBuilderGetMemoryPool =
+        (nvnBufferBuilderGetMemoryPoolFunction)deviceGetProcAddress(
+            device, "nvnBufferBuilderGetMemoryPool");
+    pfnc_nvnBufferBuilderGetMemoryOffset =
+        (nvnBufferBuilderGetMemoryOffsetFunction)deviceGetProcAddress(
+            device, "nvnBufferBuilderGetMemoryOffset");
+    pfnc_nvnBufferBuilderGetSize =
+        (nvnBufferBuilderGetSizeFunction)deviceGetProcAddress(device, "nvnBufferBuilderGetSize");
+    pfnc_nvnBufferInitialize =
+        (nvnBufferInitializeFunction)deviceGetProcAddress(device, "nvnBufferInitialize");
+    pfnc_nvnBufferSetDebugLabel =
+        (nvnBufferSetDebugLabelFunction)deviceGetProcAddress(device, "nvnBufferSetDebugLabel");
+    pfnc_nvnBufferFinalize =
+        (nvnBufferFinalizeFunction)deviceGetProcAddress(device, "nvnBufferFinalize");
     pfnc_nvnBufferMap = (nvnBufferMapFunction)deviceGetProcAddress(device, "nvnBufferMap");
-    pfnc_nvnBufferGetAddress = (nvnBufferGetAddressFunction)deviceGetProcAddress(device, "nvnBufferGetAddress");
-    pfnc_nvnBufferFlushMappedRange = (nvnBufferFlushMappedRangeFunction)deviceGetProcAddress(device, "nvnBufferFlushMappedRange");
-    pfnc_nvnBufferInvalidateMappedRange = (nvnBufferInvalidateMappedRangeFunction)deviceGetProcAddress(device, "nvnBufferInvalidateMappedRange");
-    pfnc_nvnBufferGetMemoryPool = (nvnBufferGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnBufferGetMemoryPool");
-    pfnc_nvnBufferGetMemoryOffset = (nvnBufferGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnBufferGetMemoryOffset");
-    pfnc_nvnBufferGetSize = (nvnBufferGetSizeFunction)deviceGetProcAddress(device, "nvnBufferGetSize");
-    pfnc_nvnBufferGetDebugID = (nvnBufferGetDebugIDFunction)deviceGetProcAddress(device, "nvnBufferGetDebugID");
-    pfnc_nvnTextureBuilderSetDevice = (nvnTextureBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetDevice");
-    pfnc_nvnTextureBuilderSetDefaults = (nvnTextureBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetDefaults");
-    pfnc_nvnTextureBuilderSetFlags = (nvnTextureBuilderSetFlagsFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetFlags");
-    pfnc_nvnTextureBuilderSetTarget = (nvnTextureBuilderSetTargetFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetTarget");
-    pfnc_nvnTextureBuilderSetWidth = (nvnTextureBuilderSetWidthFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetWidth");
-    pfnc_nvnTextureBuilderSetHeight = (nvnTextureBuilderSetHeightFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetHeight");
-    pfnc_nvnTextureBuilderSetDepth = (nvnTextureBuilderSetDepthFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetDepth");
-    pfnc_nvnTextureBuilderSetSize1D = (nvnTextureBuilderSetSize1DFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetSize1D");
-    pfnc_nvnTextureBuilderSetSize2D = (nvnTextureBuilderSetSize2DFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetSize2D");
-    pfnc_nvnTextureBuilderSetSize3D = (nvnTextureBuilderSetSize3DFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetSize3D");
-    pfnc_nvnTextureBuilderSetLevels = (nvnTextureBuilderSetLevelsFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetLevels");
-    pfnc_nvnTextureBuilderSetFormat = (nvnTextureBuilderSetFormatFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetFormat");
-    pfnc_nvnTextureBuilderSetSamples = (nvnTextureBuilderSetSamplesFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetSamples");
-    pfnc_nvnTextureBuilderSetSwizzle = (nvnTextureBuilderSetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetSwizzle");
-    pfnc_nvnTextureBuilderSetDepthStencilMode = (nvnTextureBuilderSetDepthStencilModeFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetDepthStencilMode");
-    pfnc_nvnTextureBuilderGetStorageSize = (nvnTextureBuilderGetStorageSizeFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetStorageSize");
-    pfnc_nvnTextureBuilderGetStorageAlignment = (nvnTextureBuilderGetStorageAlignmentFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetStorageAlignment");
-    pfnc_nvnTextureBuilderSetStorage = (nvnTextureBuilderSetStorageFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetStorage");
-    pfnc_nvnTextureBuilderSetPackagedTextureData = (nvnTextureBuilderSetPackagedTextureDataFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetPackagedTextureData");
-    pfnc_nvnTextureBuilderSetPackagedTextureLayout = (nvnTextureBuilderSetPackagedTextureLayoutFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetPackagedTextureLayout");
-    pfnc_nvnTextureBuilderSetStride = (nvnTextureBuilderSetStrideFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetStride");
-    pfnc_nvnTextureBuilderSetGLTextureName = (nvnTextureBuilderSetGLTextureNameFunction)deviceGetProcAddress(device, "nvnTextureBuilderSetGLTextureName");
-    pfnc_nvnTextureBuilderGetStorageClass = (nvnTextureBuilderGetStorageClassFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetStorageClass");
-    pfnc_nvnTextureBuilderGetFlags = (nvnTextureBuilderGetFlagsFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetFlags");
-    pfnc_nvnTextureBuilderGetTarget = (nvnTextureBuilderGetTargetFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetTarget");
-    pfnc_nvnTextureBuilderGetWidth = (nvnTextureBuilderGetWidthFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetWidth");
-    pfnc_nvnTextureBuilderGetHeight = (nvnTextureBuilderGetHeightFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetHeight");
-    pfnc_nvnTextureBuilderGetDepth = (nvnTextureBuilderGetDepthFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetDepth");
-    pfnc_nvnTextureBuilderGetLevels = (nvnTextureBuilderGetLevelsFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetLevels");
-    pfnc_nvnTextureBuilderGetFormat = (nvnTextureBuilderGetFormatFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetFormat");
-    pfnc_nvnTextureBuilderGetSamples = (nvnTextureBuilderGetSamplesFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetSamples");
-    pfnc_nvnTextureBuilderGetSwizzle = (nvnTextureBuilderGetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetSwizzle");
-    pfnc_nvnTextureBuilderGetDepthStencilMode = (nvnTextureBuilderGetDepthStencilModeFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetDepthStencilMode");
-    pfnc_nvnTextureBuilderGetPackagedTextureData = (nvnTextureBuilderGetPackagedTextureDataFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetPackagedTextureData");
-    pfnc_nvnTextureBuilderGetStride = (nvnTextureBuilderGetStrideFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetStride");
-    pfnc_nvnTextureBuilderGetSparseTileLayout = (nvnTextureBuilderGetSparseTileLayoutFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetSparseTileLayout");
-    pfnc_nvnTextureBuilderGetGLTextureName = (nvnTextureBuilderGetGLTextureNameFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetGLTextureName");
-    pfnc_nvnTextureBuilderGetZCullStorageSize = (nvnTextureBuilderGetZCullStorageSizeFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetZCullStorageSize");
-    pfnc_nvnTextureBuilderGetMemoryPool = (nvnTextureBuilderGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetMemoryPool");
-    pfnc_nvnTextureBuilderGetMemoryOffset = (nvnTextureBuilderGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnTextureBuilderGetMemoryOffset");
-    pfnc_nvnTextureViewSetDefaults = (nvnTextureViewSetDefaultsFunction)deviceGetProcAddress(device, "nvnTextureViewSetDefaults");
-    pfnc_nvnTextureViewSetLevels = (nvnTextureViewSetLevelsFunction)deviceGetProcAddress(device, "nvnTextureViewSetLevels");
-    pfnc_nvnTextureViewSetLayers = (nvnTextureViewSetLayersFunction)deviceGetProcAddress(device, "nvnTextureViewSetLayers");
-    pfnc_nvnTextureViewSetFormat = (nvnTextureViewSetFormatFunction)deviceGetProcAddress(device, "nvnTextureViewSetFormat");
-    pfnc_nvnTextureViewSetSwizzle = (nvnTextureViewSetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureViewSetSwizzle");
-    pfnc_nvnTextureViewSetDepthStencilMode = (nvnTextureViewSetDepthStencilModeFunction)deviceGetProcAddress(device, "nvnTextureViewSetDepthStencilMode");
-    pfnc_nvnTextureViewSetTarget = (nvnTextureViewSetTargetFunction)deviceGetProcAddress(device, "nvnTextureViewSetTarget");
-    pfnc_nvnTextureViewGetLevels = (nvnTextureViewGetLevelsFunction)deviceGetProcAddress(device, "nvnTextureViewGetLevels");
-    pfnc_nvnTextureViewGetLayers = (nvnTextureViewGetLayersFunction)deviceGetProcAddress(device, "nvnTextureViewGetLayers");
-    pfnc_nvnTextureViewGetFormat = (nvnTextureViewGetFormatFunction)deviceGetProcAddress(device, "nvnTextureViewGetFormat");
-    pfnc_nvnTextureViewGetSwizzle = (nvnTextureViewGetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureViewGetSwizzle");
-    pfnc_nvnTextureViewGetDepthStencilMode = (nvnTextureViewGetDepthStencilModeFunction)deviceGetProcAddress(device, "nvnTextureViewGetDepthStencilMode");
-    pfnc_nvnTextureViewGetTarget = (nvnTextureViewGetTargetFunction)deviceGetProcAddress(device, "nvnTextureViewGetTarget");
-    pfnc_nvnTextureViewCompare = (nvnTextureViewCompareFunction)deviceGetProcAddress(device, "nvnTextureViewCompare");
-    pfnc_nvnTextureInitialize = (nvnTextureInitializeFunction)deviceGetProcAddress(device, "nvnTextureInitialize");
-    pfnc_nvnTextureGetZCullStorageSize = (nvnTextureGetZCullStorageSizeFunction)deviceGetProcAddress(device, "nvnTextureGetZCullStorageSize");
-    pfnc_nvnTextureFinalize = (nvnTextureFinalizeFunction)deviceGetProcAddress(device, "nvnTextureFinalize");
-    pfnc_nvnTextureSetDebugLabel = (nvnTextureSetDebugLabelFunction)deviceGetProcAddress(device, "nvnTextureSetDebugLabel");
-    pfnc_nvnTextureGetStorageClass = (nvnTextureGetStorageClassFunction)deviceGetProcAddress(device, "nvnTextureGetStorageClass");
-    pfnc_nvnTextureGetViewOffset = (nvnTextureGetViewOffsetFunction)deviceGetProcAddress(device, "nvnTextureGetViewOffset");
-    pfnc_nvnTextureGetFlags = (nvnTextureGetFlagsFunction)deviceGetProcAddress(device, "nvnTextureGetFlags");
-    pfnc_nvnTextureGetTarget = (nvnTextureGetTargetFunction)deviceGetProcAddress(device, "nvnTextureGetTarget");
-    pfnc_nvnTextureGetWidth = (nvnTextureGetWidthFunction)deviceGetProcAddress(device, "nvnTextureGetWidth");
-    pfnc_nvnTextureGetHeight = (nvnTextureGetHeightFunction)deviceGetProcAddress(device, "nvnTextureGetHeight");
-    pfnc_nvnTextureGetDepth = (nvnTextureGetDepthFunction)deviceGetProcAddress(device, "nvnTextureGetDepth");
-    pfnc_nvnTextureGetLevels = (nvnTextureGetLevelsFunction)deviceGetProcAddress(device, "nvnTextureGetLevels");
-    pfnc_nvnTextureGetFormat = (nvnTextureGetFormatFunction)deviceGetProcAddress(device, "nvnTextureGetFormat");
-    pfnc_nvnTextureGetSamples = (nvnTextureGetSamplesFunction)deviceGetProcAddress(device, "nvnTextureGetSamples");
-    pfnc_nvnTextureGetSwizzle = (nvnTextureGetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureGetSwizzle");
-    pfnc_nvnTextureGetDepthStencilMode = (nvnTextureGetDepthStencilModeFunction)deviceGetProcAddress(device, "nvnTextureGetDepthStencilMode");
-    pfnc_nvnTextureGetStride = (nvnTextureGetStrideFunction)deviceGetProcAddress(device, "nvnTextureGetStride");
-    pfnc_nvnTextureGetTextureAddress = (nvnTextureGetTextureAddressFunction)deviceGetProcAddress(device, "nvnTextureGetTextureAddress");
-    pfnc_nvnTextureGetSparseTileLayout = (nvnTextureGetSparseTileLayoutFunction)deviceGetProcAddress(device, "nvnTextureGetSparseTileLayout");
-    pfnc_nvnTextureWriteTexels = (nvnTextureWriteTexelsFunction)deviceGetProcAddress(device, "nvnTextureWriteTexels");
-    pfnc_nvnTextureWriteTexelsStrided = (nvnTextureWriteTexelsStridedFunction)deviceGetProcAddress(device, "nvnTextureWriteTexelsStrided");
-    pfnc_nvnTextureReadTexels = (nvnTextureReadTexelsFunction)deviceGetProcAddress(device, "nvnTextureReadTexels");
-    pfnc_nvnTextureReadTexelsStrided = (nvnTextureReadTexelsStridedFunction)deviceGetProcAddress(device, "nvnTextureReadTexelsStrided");
-    pfnc_nvnTextureFlushTexels = (nvnTextureFlushTexelsFunction)deviceGetProcAddress(device, "nvnTextureFlushTexels");
-    pfnc_nvnTextureInvalidateTexels = (nvnTextureInvalidateTexelsFunction)deviceGetProcAddress(device, "nvnTextureInvalidateTexels");
-    pfnc_nvnTextureGetMemoryPool = (nvnTextureGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnTextureGetMemoryPool");
-    pfnc_nvnTextureGetMemoryOffset = (nvnTextureGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnTextureGetMemoryOffset");
-    pfnc_nvnTextureGetStorageSize = (nvnTextureGetStorageSizeFunction)deviceGetProcAddress(device, "nvnTextureGetStorageSize");
-    pfnc_nvnTextureCompare = (nvnTextureCompareFunction)deviceGetProcAddress(device, "nvnTextureCompare");
-    pfnc_nvnTextureGetDebugID = (nvnTextureGetDebugIDFunction)deviceGetProcAddress(device, "nvnTextureGetDebugID");
-    pfnc_nvnSamplerBuilderSetDevice = (nvnSamplerBuilderSetDeviceFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetDevice");
-    pfnc_nvnSamplerBuilderSetDefaults = (nvnSamplerBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetDefaults");
-    pfnc_nvnSamplerBuilderSetMinMagFilter = (nvnSamplerBuilderSetMinMagFilterFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetMinMagFilter");
-    pfnc_nvnSamplerBuilderSetWrapMode = (nvnSamplerBuilderSetWrapModeFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetWrapMode");
-    pfnc_nvnSamplerBuilderSetLodClamp = (nvnSamplerBuilderSetLodClampFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetLodClamp");
-    pfnc_nvnSamplerBuilderSetLodBias = (nvnSamplerBuilderSetLodBiasFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetLodBias");
-    pfnc_nvnSamplerBuilderSetCompare = (nvnSamplerBuilderSetCompareFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetCompare");
-    pfnc_nvnSamplerBuilderSetBorderColor = (nvnSamplerBuilderSetBorderColorFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetBorderColor");
-    pfnc_nvnSamplerBuilderSetBorderColori = (nvnSamplerBuilderSetBorderColoriFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetBorderColori");
-    pfnc_nvnSamplerBuilderSetBorderColorui = (nvnSamplerBuilderSetBorderColoruiFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetBorderColorui");
-    pfnc_nvnSamplerBuilderSetMaxAnisotropy = (nvnSamplerBuilderSetMaxAnisotropyFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetMaxAnisotropy");
-    pfnc_nvnSamplerBuilderSetReductionFilter = (nvnSamplerBuilderSetReductionFilterFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetReductionFilter");
-    pfnc_nvnSamplerBuilderSetLodSnap = (nvnSamplerBuilderSetLodSnapFunction)deviceGetProcAddress(device, "nvnSamplerBuilderSetLodSnap");
-    pfnc_nvnSamplerBuilderGetMinMagFilter = (nvnSamplerBuilderGetMinMagFilterFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetMinMagFilter");
-    pfnc_nvnSamplerBuilderGetWrapMode = (nvnSamplerBuilderGetWrapModeFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetWrapMode");
-    pfnc_nvnSamplerBuilderGetLodClamp = (nvnSamplerBuilderGetLodClampFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetLodClamp");
-    pfnc_nvnSamplerBuilderGetLodBias = (nvnSamplerBuilderGetLodBiasFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetLodBias");
-    pfnc_nvnSamplerBuilderGetCompare = (nvnSamplerBuilderGetCompareFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetCompare");
-    pfnc_nvnSamplerBuilderGetBorderColor = (nvnSamplerBuilderGetBorderColorFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetBorderColor");
-    pfnc_nvnSamplerBuilderGetBorderColori = (nvnSamplerBuilderGetBorderColoriFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetBorderColori");
-    pfnc_nvnSamplerBuilderGetBorderColorui = (nvnSamplerBuilderGetBorderColoruiFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetBorderColorui");
-    pfnc_nvnSamplerBuilderGetMaxAnisotropy = (nvnSamplerBuilderGetMaxAnisotropyFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetMaxAnisotropy");
-    pfnc_nvnSamplerBuilderGetReductionFilter = (nvnSamplerBuilderGetReductionFilterFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetReductionFilter");
-    pfnc_nvnSamplerBuilderGetLodSnap = (nvnSamplerBuilderGetLodSnapFunction)deviceGetProcAddress(device, "nvnSamplerBuilderGetLodSnap");
-    pfnc_nvnSamplerInitialize = (nvnSamplerInitializeFunction)deviceGetProcAddress(device, "nvnSamplerInitialize");
-    pfnc_nvnSamplerFinalize = (nvnSamplerFinalizeFunction)deviceGetProcAddress(device, "nvnSamplerFinalize");
-    pfnc_nvnSamplerSetDebugLabel = (nvnSamplerSetDebugLabelFunction)deviceGetProcAddress(device, "nvnSamplerSetDebugLabel");
-    pfnc_nvnSamplerGetMinMagFilter = (nvnSamplerGetMinMagFilterFunction)deviceGetProcAddress(device, "nvnSamplerGetMinMagFilter");
-    pfnc_nvnSamplerGetWrapMode = (nvnSamplerGetWrapModeFunction)deviceGetProcAddress(device, "nvnSamplerGetWrapMode");
-    pfnc_nvnSamplerGetLodClamp = (nvnSamplerGetLodClampFunction)deviceGetProcAddress(device, "nvnSamplerGetLodClamp");
-    pfnc_nvnSamplerGetLodBias = (nvnSamplerGetLodBiasFunction)deviceGetProcAddress(device, "nvnSamplerGetLodBias");
-    pfnc_nvnSamplerGetCompare = (nvnSamplerGetCompareFunction)deviceGetProcAddress(device, "nvnSamplerGetCompare");
-    pfnc_nvnSamplerGetBorderColor = (nvnSamplerGetBorderColorFunction)deviceGetProcAddress(device, "nvnSamplerGetBorderColor");
-    pfnc_nvnSamplerGetBorderColori = (nvnSamplerGetBorderColoriFunction)deviceGetProcAddress(device, "nvnSamplerGetBorderColori");
-    pfnc_nvnSamplerGetBorderColorui = (nvnSamplerGetBorderColoruiFunction)deviceGetProcAddress(device, "nvnSamplerGetBorderColorui");
-    pfnc_nvnSamplerGetMaxAnisotropy = (nvnSamplerGetMaxAnisotropyFunction)deviceGetProcAddress(device, "nvnSamplerGetMaxAnisotropy");
-    pfnc_nvnSamplerGetReductionFilter = (nvnSamplerGetReductionFilterFunction)deviceGetProcAddress(device, "nvnSamplerGetReductionFilter");
-    pfnc_nvnSamplerCompare = (nvnSamplerCompareFunction)deviceGetProcAddress(device, "nvnSamplerCompare");
-    pfnc_nvnSamplerGetDebugID = (nvnSamplerGetDebugIDFunction)deviceGetProcAddress(device, "nvnSamplerGetDebugID");
-    pfnc_nvnBlendStateSetDefaults = (nvnBlendStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnBlendStateSetDefaults");
-    pfnc_nvnBlendStateSetBlendTarget = (nvnBlendStateSetBlendTargetFunction)deviceGetProcAddress(device, "nvnBlendStateSetBlendTarget");
-    pfnc_nvnBlendStateSetBlendFunc = (nvnBlendStateSetBlendFuncFunction)deviceGetProcAddress(device, "nvnBlendStateSetBlendFunc");
-    pfnc_nvnBlendStateSetBlendEquation = (nvnBlendStateSetBlendEquationFunction)deviceGetProcAddress(device, "nvnBlendStateSetBlendEquation");
-    pfnc_nvnBlendStateSetAdvancedMode = (nvnBlendStateSetAdvancedModeFunction)deviceGetProcAddress(device, "nvnBlendStateSetAdvancedMode");
-    pfnc_nvnBlendStateSetAdvancedOverlap = (nvnBlendStateSetAdvancedOverlapFunction)deviceGetProcAddress(device, "nvnBlendStateSetAdvancedOverlap");
-    pfnc_nvnBlendStateSetAdvancedPremultipliedSrc = (nvnBlendStateSetAdvancedPremultipliedSrcFunction)deviceGetProcAddress(device, "nvnBlendStateSetAdvancedPremultipliedSrc");
-    pfnc_nvnBlendStateSetAdvancedNormalizedDst = (nvnBlendStateSetAdvancedNormalizedDstFunction)deviceGetProcAddress(device, "nvnBlendStateSetAdvancedNormalizedDst");
-    pfnc_nvnBlendStateGetBlendTarget = (nvnBlendStateGetBlendTargetFunction)deviceGetProcAddress(device, "nvnBlendStateGetBlendTarget");
-    pfnc_nvnBlendStateGetBlendFunc = (nvnBlendStateGetBlendFuncFunction)deviceGetProcAddress(device, "nvnBlendStateGetBlendFunc");
-    pfnc_nvnBlendStateGetBlendEquation = (nvnBlendStateGetBlendEquationFunction)deviceGetProcAddress(device, "nvnBlendStateGetBlendEquation");
-    pfnc_nvnBlendStateGetAdvancedMode = (nvnBlendStateGetAdvancedModeFunction)deviceGetProcAddress(device, "nvnBlendStateGetAdvancedMode");
-    pfnc_nvnBlendStateGetAdvancedOverlap = (nvnBlendStateGetAdvancedOverlapFunction)deviceGetProcAddress(device, "nvnBlendStateGetAdvancedOverlap");
-    pfnc_nvnBlendStateGetAdvancedPremultipliedSrc = (nvnBlendStateGetAdvancedPremultipliedSrcFunction)deviceGetProcAddress(device, "nvnBlendStateGetAdvancedPremultipliedSrc");
-    pfnc_nvnBlendStateGetAdvancedNormalizedDst = (nvnBlendStateGetAdvancedNormalizedDstFunction)deviceGetProcAddress(device, "nvnBlendStateGetAdvancedNormalizedDst");
-    pfnc_nvnColorStateSetDefaults = (nvnColorStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnColorStateSetDefaults");
-    pfnc_nvnColorStateSetBlendEnable = (nvnColorStateSetBlendEnableFunction)deviceGetProcAddress(device, "nvnColorStateSetBlendEnable");
-    pfnc_nvnColorStateSetLogicOp = (nvnColorStateSetLogicOpFunction)deviceGetProcAddress(device, "nvnColorStateSetLogicOp");
-    pfnc_nvnColorStateSetAlphaTest = (nvnColorStateSetAlphaTestFunction)deviceGetProcAddress(device, "nvnColorStateSetAlphaTest");
-    pfnc_nvnColorStateGetBlendEnable = (nvnColorStateGetBlendEnableFunction)deviceGetProcAddress(device, "nvnColorStateGetBlendEnable");
-    pfnc_nvnColorStateGetLogicOp = (nvnColorStateGetLogicOpFunction)deviceGetProcAddress(device, "nvnColorStateGetLogicOp");
-    pfnc_nvnColorStateGetAlphaTest = (nvnColorStateGetAlphaTestFunction)deviceGetProcAddress(device, "nvnColorStateGetAlphaTest");
-    pfnc_nvnChannelMaskStateSetDefaults = (nvnChannelMaskStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnChannelMaskStateSetDefaults");
-    pfnc_nvnChannelMaskStateSetChannelMask = (nvnChannelMaskStateSetChannelMaskFunction)deviceGetProcAddress(device, "nvnChannelMaskStateSetChannelMask");
-    pfnc_nvnChannelMaskStateGetChannelMask = (nvnChannelMaskStateGetChannelMaskFunction)deviceGetProcAddress(device, "nvnChannelMaskStateGetChannelMask");
-    pfnc_nvnMultisampleStateSetDefaults = (nvnMultisampleStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetDefaults");
-    pfnc_nvnMultisampleStateSetMultisampleEnable = (nvnMultisampleStateSetMultisampleEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetMultisampleEnable");
-    pfnc_nvnMultisampleStateSetSamples = (nvnMultisampleStateSetSamplesFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetSamples");
-    pfnc_nvnMultisampleStateSetAlphaToCoverageEnable = (nvnMultisampleStateSetAlphaToCoverageEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetAlphaToCoverageEnable");
-    pfnc_nvnMultisampleStateSetAlphaToCoverageDither = (nvnMultisampleStateSetAlphaToCoverageDitherFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetAlphaToCoverageDither");
-    pfnc_nvnMultisampleStateGetMultisampleEnable = (nvnMultisampleStateGetMultisampleEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetMultisampleEnable");
-    pfnc_nvnMultisampleStateGetSamples = (nvnMultisampleStateGetSamplesFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetSamples");
-    pfnc_nvnMultisampleStateGetAlphaToCoverageEnable = (nvnMultisampleStateGetAlphaToCoverageEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetAlphaToCoverageEnable");
-    pfnc_nvnMultisampleStateGetAlphaToCoverageDither = (nvnMultisampleStateGetAlphaToCoverageDitherFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetAlphaToCoverageDither");
-    pfnc_nvnMultisampleStateSetRasterSamples = (nvnMultisampleStateSetRasterSamplesFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetRasterSamples");
-    pfnc_nvnMultisampleStateGetRasterSamples = (nvnMultisampleStateGetRasterSamplesFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetRasterSamples");
-    pfnc_nvnMultisampleStateSetCoverageModulationMode = (nvnMultisampleStateSetCoverageModulationModeFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetCoverageModulationMode");
-    pfnc_nvnMultisampleStateGetCoverageModulationMode = (nvnMultisampleStateGetCoverageModulationModeFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetCoverageModulationMode");
-    pfnc_nvnMultisampleStateSetCoverageToColorEnable = (nvnMultisampleStateSetCoverageToColorEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetCoverageToColorEnable");
-    pfnc_nvnMultisampleStateGetCoverageToColorEnable = (nvnMultisampleStateGetCoverageToColorEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetCoverageToColorEnable");
-    pfnc_nvnMultisampleStateSetCoverageToColorOutput = (nvnMultisampleStateSetCoverageToColorOutputFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetCoverageToColorOutput");
-    pfnc_nvnMultisampleStateGetCoverageToColorOutput = (nvnMultisampleStateGetCoverageToColorOutputFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetCoverageToColorOutput");
-    pfnc_nvnMultisampleStateSetSampleLocationsEnable = (nvnMultisampleStateSetSampleLocationsEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetSampleLocationsEnable");
-    pfnc_nvnMultisampleStateGetSampleLocationsEnable = (nvnMultisampleStateGetSampleLocationsEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetSampleLocationsEnable");
-    pfnc_nvnMultisampleStateGetSampleLocationsGrid = (nvnMultisampleStateGetSampleLocationsGridFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetSampleLocationsGrid");
-    pfnc_nvnMultisampleStateSetSampleLocationsGridEnable = (nvnMultisampleStateSetSampleLocationsGridEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetSampleLocationsGridEnable");
-    pfnc_nvnMultisampleStateGetSampleLocationsGridEnable = (nvnMultisampleStateGetSampleLocationsGridEnableFunction)deviceGetProcAddress(device, "nvnMultisampleStateGetSampleLocationsGridEnable");
-    pfnc_nvnMultisampleStateSetSampleLocations = (nvnMultisampleStateSetSampleLocationsFunction)deviceGetProcAddress(device, "nvnMultisampleStateSetSampleLocations");
-    pfnc_nvnPolygonStateSetDefaults = (nvnPolygonStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnPolygonStateSetDefaults");
-    pfnc_nvnPolygonStateSetCullFace = (nvnPolygonStateSetCullFaceFunction)deviceGetProcAddress(device, "nvnPolygonStateSetCullFace");
-    pfnc_nvnPolygonStateSetFrontFace = (nvnPolygonStateSetFrontFaceFunction)deviceGetProcAddress(device, "nvnPolygonStateSetFrontFace");
-    pfnc_nvnPolygonStateSetPolygonMode = (nvnPolygonStateSetPolygonModeFunction)deviceGetProcAddress(device, "nvnPolygonStateSetPolygonMode");
-    pfnc_nvnPolygonStateSetPolygonOffsetEnables = (nvnPolygonStateSetPolygonOffsetEnablesFunction)deviceGetProcAddress(device, "nvnPolygonStateSetPolygonOffsetEnables");
-    pfnc_nvnPolygonStateGetCullFace = (nvnPolygonStateGetCullFaceFunction)deviceGetProcAddress(device, "nvnPolygonStateGetCullFace");
-    pfnc_nvnPolygonStateGetFrontFace = (nvnPolygonStateGetFrontFaceFunction)deviceGetProcAddress(device, "nvnPolygonStateGetFrontFace");
-    pfnc_nvnPolygonStateGetPolygonMode = (nvnPolygonStateGetPolygonModeFunction)deviceGetProcAddress(device, "nvnPolygonStateGetPolygonMode");
-    pfnc_nvnPolygonStateGetPolygonOffsetEnables = (nvnPolygonStateGetPolygonOffsetEnablesFunction)deviceGetProcAddress(device, "nvnPolygonStateGetPolygonOffsetEnables");
-    pfnc_nvnDepthStencilStateSetDefaults = (nvnDepthStencilStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetDefaults");
-    pfnc_nvnDepthStencilStateSetDepthTestEnable = (nvnDepthStencilStateSetDepthTestEnableFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetDepthTestEnable");
-    pfnc_nvnDepthStencilStateSetDepthWriteEnable = (nvnDepthStencilStateSetDepthWriteEnableFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetDepthWriteEnable");
-    pfnc_nvnDepthStencilStateSetDepthFunc = (nvnDepthStencilStateSetDepthFuncFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetDepthFunc");
-    pfnc_nvnDepthStencilStateSetStencilTestEnable = (nvnDepthStencilStateSetStencilTestEnableFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetStencilTestEnable");
-    pfnc_nvnDepthStencilStateSetStencilFunc = (nvnDepthStencilStateSetStencilFuncFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetStencilFunc");
-    pfnc_nvnDepthStencilStateSetStencilOp = (nvnDepthStencilStateSetStencilOpFunction)deviceGetProcAddress(device, "nvnDepthStencilStateSetStencilOp");
-    pfnc_nvnDepthStencilStateGetDepthTestEnable = (nvnDepthStencilStateGetDepthTestEnableFunction)deviceGetProcAddress(device, "nvnDepthStencilStateGetDepthTestEnable");
-    pfnc_nvnDepthStencilStateGetDepthWriteEnable = (nvnDepthStencilStateGetDepthWriteEnableFunction)deviceGetProcAddress(device, "nvnDepthStencilStateGetDepthWriteEnable");
-    pfnc_nvnDepthStencilStateGetDepthFunc = (nvnDepthStencilStateGetDepthFuncFunction)deviceGetProcAddress(device, "nvnDepthStencilStateGetDepthFunc");
-    pfnc_nvnDepthStencilStateGetStencilTestEnable = (nvnDepthStencilStateGetStencilTestEnableFunction)deviceGetProcAddress(device, "nvnDepthStencilStateGetStencilTestEnable");
-    pfnc_nvnDepthStencilStateGetStencilFunc = (nvnDepthStencilStateGetStencilFuncFunction)deviceGetProcAddress(device, "nvnDepthStencilStateGetStencilFunc");
-    pfnc_nvnDepthStencilStateGetStencilOp = (nvnDepthStencilStateGetStencilOpFunction)deviceGetProcAddress(device, "nvnDepthStencilStateGetStencilOp");
-    pfnc_nvnVertexAttribStateSetDefaults = (nvnVertexAttribStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnVertexAttribStateSetDefaults");
-    pfnc_nvnVertexAttribStateSetFormat = (nvnVertexAttribStateSetFormatFunction)deviceGetProcAddress(device, "nvnVertexAttribStateSetFormat");
-    pfnc_nvnVertexAttribStateSetStreamIndex = (nvnVertexAttribStateSetStreamIndexFunction)deviceGetProcAddress(device, "nvnVertexAttribStateSetStreamIndex");
-    pfnc_nvnVertexAttribStateGetFormat = (nvnVertexAttribStateGetFormatFunction)deviceGetProcAddress(device, "nvnVertexAttribStateGetFormat");
-    pfnc_nvnVertexAttribStateGetStreamIndex = (nvnVertexAttribStateGetStreamIndexFunction)deviceGetProcAddress(device, "nvnVertexAttribStateGetStreamIndex");
-    pfnc_nvnVertexStreamStateSetDefaults = (nvnVertexStreamStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnVertexStreamStateSetDefaults");
-    pfnc_nvnVertexStreamStateSetStride = (nvnVertexStreamStateSetStrideFunction)deviceGetProcAddress(device, "nvnVertexStreamStateSetStride");
-    pfnc_nvnVertexStreamStateSetDivisor = (nvnVertexStreamStateSetDivisorFunction)deviceGetProcAddress(device, "nvnVertexStreamStateSetDivisor");
-    pfnc_nvnVertexStreamStateGetStride = (nvnVertexStreamStateGetStrideFunction)deviceGetProcAddress(device, "nvnVertexStreamStateGetStride");
-    pfnc_nvnVertexStreamStateGetDivisor = (nvnVertexStreamStateGetDivisorFunction)deviceGetProcAddress(device, "nvnVertexStreamStateGetDivisor");
-    pfnc_nvnCommandBufferInitialize = (nvnCommandBufferInitializeFunction)deviceGetProcAddress(device, "nvnCommandBufferInitialize");
-    pfnc_nvnCommandBufferFinalize = (nvnCommandBufferFinalizeFunction)deviceGetProcAddress(device, "nvnCommandBufferFinalize");
-    pfnc_nvnCommandBufferSetDebugLabel = (nvnCommandBufferSetDebugLabelFunction)deviceGetProcAddress(device, "nvnCommandBufferSetDebugLabel");
-    pfnc_nvnCommandBufferSetMemoryCallback = (nvnCommandBufferSetMemoryCallbackFunction)deviceGetProcAddress(device, "nvnCommandBufferSetMemoryCallback");
-    pfnc_nvnCommandBufferSetMemoryCallbackData = (nvnCommandBufferSetMemoryCallbackDataFunction)deviceGetProcAddress(device, "nvnCommandBufferSetMemoryCallbackData");
-    pfnc_nvnCommandBufferAddCommandMemory = (nvnCommandBufferAddCommandMemoryFunction)deviceGetProcAddress(device, "nvnCommandBufferAddCommandMemory");
-    pfnc_nvnCommandBufferAddControlMemory = (nvnCommandBufferAddControlMemoryFunction)deviceGetProcAddress(device, "nvnCommandBufferAddControlMemory");
-    pfnc_nvnCommandBufferGetCommandMemorySize = (nvnCommandBufferGetCommandMemorySizeFunction)deviceGetProcAddress(device, "nvnCommandBufferGetCommandMemorySize");
-    pfnc_nvnCommandBufferGetCommandMemoryUsed = (nvnCommandBufferGetCommandMemoryUsedFunction)deviceGetProcAddress(device, "nvnCommandBufferGetCommandMemoryUsed");
-    pfnc_nvnCommandBufferGetCommandMemoryFree = (nvnCommandBufferGetCommandMemoryFreeFunction)deviceGetProcAddress(device, "nvnCommandBufferGetCommandMemoryFree");
-    pfnc_nvnCommandBufferGetControlMemorySize = (nvnCommandBufferGetControlMemorySizeFunction)deviceGetProcAddress(device, "nvnCommandBufferGetControlMemorySize");
-    pfnc_nvnCommandBufferGetControlMemoryUsed = (nvnCommandBufferGetControlMemoryUsedFunction)deviceGetProcAddress(device, "nvnCommandBufferGetControlMemoryUsed");
-    pfnc_nvnCommandBufferGetControlMemoryFree = (nvnCommandBufferGetControlMemoryFreeFunction)deviceGetProcAddress(device, "nvnCommandBufferGetControlMemoryFree");
-    pfnc_nvnCommandBufferBeginRecording = (nvnCommandBufferBeginRecordingFunction)deviceGetProcAddress(device, "nvnCommandBufferBeginRecording");
-    pfnc_nvnCommandBufferEndRecording = (nvnCommandBufferEndRecordingFunction)deviceGetProcAddress(device, "nvnCommandBufferEndRecording");
-    pfnc_nvnCommandBufferCallCommands = (nvnCommandBufferCallCommandsFunction)deviceGetProcAddress(device, "nvnCommandBufferCallCommands");
-    pfnc_nvnCommandBufferCopyCommands = (nvnCommandBufferCopyCommandsFunction)deviceGetProcAddress(device, "nvnCommandBufferCopyCommands");
-    pfnc_nvnCommandBufferBindBlendState = (nvnCommandBufferBindBlendStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindBlendState");
-    pfnc_nvnCommandBufferBindChannelMaskState = (nvnCommandBufferBindChannelMaskStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindChannelMaskState");
-    pfnc_nvnCommandBufferBindColorState = (nvnCommandBufferBindColorStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindColorState");
-    pfnc_nvnCommandBufferBindMultisampleState = (nvnCommandBufferBindMultisampleStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindMultisampleState");
-    pfnc_nvnCommandBufferBindPolygonState = (nvnCommandBufferBindPolygonStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindPolygonState");
-    pfnc_nvnCommandBufferBindDepthStencilState = (nvnCommandBufferBindDepthStencilStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindDepthStencilState");
-    pfnc_nvnCommandBufferBindVertexAttribState = (nvnCommandBufferBindVertexAttribStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindVertexAttribState");
-    pfnc_nvnCommandBufferBindVertexStreamState = (nvnCommandBufferBindVertexStreamStateFunction)deviceGetProcAddress(device, "nvnCommandBufferBindVertexStreamState");
-    pfnc_nvnCommandBufferBindProgram = (nvnCommandBufferBindProgramFunction)deviceGetProcAddress(device, "nvnCommandBufferBindProgram");
-    pfnc_nvnCommandBufferBindVertexBuffer = (nvnCommandBufferBindVertexBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferBindVertexBuffer");
-    pfnc_nvnCommandBufferBindVertexBuffers = (nvnCommandBufferBindVertexBuffersFunction)deviceGetProcAddress(device, "nvnCommandBufferBindVertexBuffers");
-    pfnc_nvnCommandBufferBindUniformBuffer = (nvnCommandBufferBindUniformBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferBindUniformBuffer");
-    pfnc_nvnCommandBufferBindUniformBuffers = (nvnCommandBufferBindUniformBuffersFunction)deviceGetProcAddress(device, "nvnCommandBufferBindUniformBuffers");
-    pfnc_nvnCommandBufferBindTransformFeedbackBuffer = (nvnCommandBufferBindTransformFeedbackBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferBindTransformFeedbackBuffer");
-    pfnc_nvnCommandBufferBindTransformFeedbackBuffers = (nvnCommandBufferBindTransformFeedbackBuffersFunction)deviceGetProcAddress(device, "nvnCommandBufferBindTransformFeedbackBuffers");
-    pfnc_nvnCommandBufferBindStorageBuffer = (nvnCommandBufferBindStorageBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferBindStorageBuffer");
-    pfnc_nvnCommandBufferBindStorageBuffers = (nvnCommandBufferBindStorageBuffersFunction)deviceGetProcAddress(device, "nvnCommandBufferBindStorageBuffers");
-    pfnc_nvnCommandBufferBindTexture = (nvnCommandBufferBindTextureFunction)deviceGetProcAddress(device, "nvnCommandBufferBindTexture");
-    pfnc_nvnCommandBufferBindTextures = (nvnCommandBufferBindTexturesFunction)deviceGetProcAddress(device, "nvnCommandBufferBindTextures");
-    pfnc_nvnCommandBufferBindImage = (nvnCommandBufferBindImageFunction)deviceGetProcAddress(device, "nvnCommandBufferBindImage");
-    pfnc_nvnCommandBufferBindImages = (nvnCommandBufferBindImagesFunction)deviceGetProcAddress(device, "nvnCommandBufferBindImages");
-    pfnc_nvnCommandBufferSetPatchSize = (nvnCommandBufferSetPatchSizeFunction)deviceGetProcAddress(device, "nvnCommandBufferSetPatchSize");
-    pfnc_nvnCommandBufferSetInnerTessellationLevels = (nvnCommandBufferSetInnerTessellationLevelsFunction)deviceGetProcAddress(device, "nvnCommandBufferSetInnerTessellationLevels");
-    pfnc_nvnCommandBufferSetOuterTessellationLevels = (nvnCommandBufferSetOuterTessellationLevelsFunction)deviceGetProcAddress(device, "nvnCommandBufferSetOuterTessellationLevels");
-    pfnc_nvnCommandBufferSetPrimitiveRestart = (nvnCommandBufferSetPrimitiveRestartFunction)deviceGetProcAddress(device, "nvnCommandBufferSetPrimitiveRestart");
-    pfnc_nvnCommandBufferBeginTransformFeedback = (nvnCommandBufferBeginTransformFeedbackFunction)deviceGetProcAddress(device, "nvnCommandBufferBeginTransformFeedback");
-    pfnc_nvnCommandBufferEndTransformFeedback = (nvnCommandBufferEndTransformFeedbackFunction)deviceGetProcAddress(device, "nvnCommandBufferEndTransformFeedback");
-    pfnc_nvnCommandBufferPauseTransformFeedback = (nvnCommandBufferPauseTransformFeedbackFunction)deviceGetProcAddress(device, "nvnCommandBufferPauseTransformFeedback");
-    pfnc_nvnCommandBufferResumeTransformFeedback = (nvnCommandBufferResumeTransformFeedbackFunction)deviceGetProcAddress(device, "nvnCommandBufferResumeTransformFeedback");
-    pfnc_nvnCommandBufferDrawTransformFeedback = (nvnCommandBufferDrawTransformFeedbackFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawTransformFeedback");
-    pfnc_nvnCommandBufferDrawArrays = (nvnCommandBufferDrawArraysFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawArrays");
-    pfnc_nvnCommandBufferDrawElements = (nvnCommandBufferDrawElementsFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawElements");
-    pfnc_nvnCommandBufferDrawElementsBaseVertex = (nvnCommandBufferDrawElementsBaseVertexFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawElementsBaseVertex");
-    pfnc_nvnCommandBufferDrawArraysInstanced = (nvnCommandBufferDrawArraysInstancedFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawArraysInstanced");
-    pfnc_nvnCommandBufferDrawElementsInstanced = (nvnCommandBufferDrawElementsInstancedFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawElementsInstanced");
-    pfnc_nvnCommandBufferDrawArraysIndirect = (nvnCommandBufferDrawArraysIndirectFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawArraysIndirect");
-    pfnc_nvnCommandBufferDrawElementsIndirect = (nvnCommandBufferDrawElementsIndirectFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawElementsIndirect");
-    pfnc_nvnCommandBufferMultiDrawArraysIndirectCount = (nvnCommandBufferMultiDrawArraysIndirectCountFunction)deviceGetProcAddress(device, "nvnCommandBufferMultiDrawArraysIndirectCount");
-    pfnc_nvnCommandBufferMultiDrawElementsIndirectCount = (nvnCommandBufferMultiDrawElementsIndirectCountFunction)deviceGetProcAddress(device, "nvnCommandBufferMultiDrawElementsIndirectCount");
-    pfnc_nvnCommandBufferClearColor = (nvnCommandBufferClearColorFunction)deviceGetProcAddress(device, "nvnCommandBufferClearColor");
-    pfnc_nvnCommandBufferClearColori = (nvnCommandBufferClearColoriFunction)deviceGetProcAddress(device, "nvnCommandBufferClearColori");
-    pfnc_nvnCommandBufferClearColorui = (nvnCommandBufferClearColoruiFunction)deviceGetProcAddress(device, "nvnCommandBufferClearColorui");
-    pfnc_nvnCommandBufferClearDepthStencil = (nvnCommandBufferClearDepthStencilFunction)deviceGetProcAddress(device, "nvnCommandBufferClearDepthStencil");
-    pfnc_nvnCommandBufferDispatchCompute = (nvnCommandBufferDispatchComputeFunction)deviceGetProcAddress(device, "nvnCommandBufferDispatchCompute");
-    pfnc_nvnCommandBufferDispatchComputeIndirect = (nvnCommandBufferDispatchComputeIndirectFunction)deviceGetProcAddress(device, "nvnCommandBufferDispatchComputeIndirect");
-    pfnc_nvnCommandBufferSetViewport = (nvnCommandBufferSetViewportFunction)deviceGetProcAddress(device, "nvnCommandBufferSetViewport");
-    pfnc_nvnCommandBufferSetViewports = (nvnCommandBufferSetViewportsFunction)deviceGetProcAddress(device, "nvnCommandBufferSetViewports");
-    pfnc_nvnCommandBufferSetViewportSwizzles = (nvnCommandBufferSetViewportSwizzlesFunction)deviceGetProcAddress(device, "nvnCommandBufferSetViewportSwizzles");
-    pfnc_nvnCommandBufferSetScissor = (nvnCommandBufferSetScissorFunction)deviceGetProcAddress(device, "nvnCommandBufferSetScissor");
-    pfnc_nvnCommandBufferSetScissors = (nvnCommandBufferSetScissorsFunction)deviceGetProcAddress(device, "nvnCommandBufferSetScissors");
-    pfnc_nvnCommandBufferSetDepthRange = (nvnCommandBufferSetDepthRangeFunction)deviceGetProcAddress(device, "nvnCommandBufferSetDepthRange");
-    pfnc_nvnCommandBufferSetDepthBounds = (nvnCommandBufferSetDepthBoundsFunction)deviceGetProcAddress(device, "nvnCommandBufferSetDepthBounds");
-    pfnc_nvnCommandBufferSetDepthRanges = (nvnCommandBufferSetDepthRangesFunction)deviceGetProcAddress(device, "nvnCommandBufferSetDepthRanges");
-    pfnc_nvnCommandBufferSetTiledCacheAction = (nvnCommandBufferSetTiledCacheActionFunction)deviceGetProcAddress(device, "nvnCommandBufferSetTiledCacheAction");
-    pfnc_nvnCommandBufferSetTiledCacheTileSize = (nvnCommandBufferSetTiledCacheTileSizeFunction)deviceGetProcAddress(device, "nvnCommandBufferSetTiledCacheTileSize");
-    pfnc_nvnCommandBufferBindSeparateTexture = (nvnCommandBufferBindSeparateTextureFunction)deviceGetProcAddress(device, "nvnCommandBufferBindSeparateTexture");
-    pfnc_nvnCommandBufferBindSeparateSampler = (nvnCommandBufferBindSeparateSamplerFunction)deviceGetProcAddress(device, "nvnCommandBufferBindSeparateSampler");
-    pfnc_nvnCommandBufferBindSeparateTextures = (nvnCommandBufferBindSeparateTexturesFunction)deviceGetProcAddress(device, "nvnCommandBufferBindSeparateTextures");
-    pfnc_nvnCommandBufferBindSeparateSamplers = (nvnCommandBufferBindSeparateSamplersFunction)deviceGetProcAddress(device, "nvnCommandBufferBindSeparateSamplers");
-    pfnc_nvnCommandBufferSetStencilValueMask = (nvnCommandBufferSetStencilValueMaskFunction)deviceGetProcAddress(device, "nvnCommandBufferSetStencilValueMask");
-    pfnc_nvnCommandBufferSetStencilMask = (nvnCommandBufferSetStencilMaskFunction)deviceGetProcAddress(device, "nvnCommandBufferSetStencilMask");
-    pfnc_nvnCommandBufferSetStencilRef = (nvnCommandBufferSetStencilRefFunction)deviceGetProcAddress(device, "nvnCommandBufferSetStencilRef");
-    pfnc_nvnCommandBufferSetBlendColor = (nvnCommandBufferSetBlendColorFunction)deviceGetProcAddress(device, "nvnCommandBufferSetBlendColor");
-    pfnc_nvnCommandBufferSetPointSize = (nvnCommandBufferSetPointSizeFunction)deviceGetProcAddress(device, "nvnCommandBufferSetPointSize");
-    pfnc_nvnCommandBufferSetLineWidth = (nvnCommandBufferSetLineWidthFunction)deviceGetProcAddress(device, "nvnCommandBufferSetLineWidth");
-    pfnc_nvnCommandBufferSetPolygonOffsetClamp = (nvnCommandBufferSetPolygonOffsetClampFunction)deviceGetProcAddress(device, "nvnCommandBufferSetPolygonOffsetClamp");
-    pfnc_nvnCommandBufferSetAlphaRef = (nvnCommandBufferSetAlphaRefFunction)deviceGetProcAddress(device, "nvnCommandBufferSetAlphaRef");
-    pfnc_nvnCommandBufferSetSampleMask = (nvnCommandBufferSetSampleMaskFunction)deviceGetProcAddress(device, "nvnCommandBufferSetSampleMask");
-    pfnc_nvnCommandBufferSetRasterizerDiscard = (nvnCommandBufferSetRasterizerDiscardFunction)deviceGetProcAddress(device, "nvnCommandBufferSetRasterizerDiscard");
-    pfnc_nvnCommandBufferSetDepthClamp = (nvnCommandBufferSetDepthClampFunction)deviceGetProcAddress(device, "nvnCommandBufferSetDepthClamp");
-    pfnc_nvnCommandBufferSetConservativeRasterEnable = (nvnCommandBufferSetConservativeRasterEnableFunction)deviceGetProcAddress(device, "nvnCommandBufferSetConservativeRasterEnable");
-    pfnc_nvnCommandBufferSetConservativeRasterDilate = (nvnCommandBufferSetConservativeRasterDilateFunction)deviceGetProcAddress(device, "nvnCommandBufferSetConservativeRasterDilate");
-    pfnc_nvnCommandBufferSetSubpixelPrecisionBias = (nvnCommandBufferSetSubpixelPrecisionBiasFunction)deviceGetProcAddress(device, "nvnCommandBufferSetSubpixelPrecisionBias");
-    pfnc_nvnCommandBufferCopyBufferToTexture = (nvnCommandBufferCopyBufferToTextureFunction)deviceGetProcAddress(device, "nvnCommandBufferCopyBufferToTexture");
-    pfnc_nvnCommandBufferCopyTextureToBuffer = (nvnCommandBufferCopyTextureToBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferCopyTextureToBuffer");
-    pfnc_nvnCommandBufferCopyTextureToTexture = (nvnCommandBufferCopyTextureToTextureFunction)deviceGetProcAddress(device, "nvnCommandBufferCopyTextureToTexture");
-    pfnc_nvnCommandBufferCopyBufferToBuffer = (nvnCommandBufferCopyBufferToBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferCopyBufferToBuffer");
-    pfnc_nvnCommandBufferClearBuffer = (nvnCommandBufferClearBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferClearBuffer");
-    pfnc_nvnCommandBufferClearTexture = (nvnCommandBufferClearTextureFunction)deviceGetProcAddress(device, "nvnCommandBufferClearTexture");
-    pfnc_nvnCommandBufferClearTexturei = (nvnCommandBufferClearTextureiFunction)deviceGetProcAddress(device, "nvnCommandBufferClearTexturei");
-    pfnc_nvnCommandBufferClearTextureui = (nvnCommandBufferClearTextureuiFunction)deviceGetProcAddress(device, "nvnCommandBufferClearTextureui");
-    pfnc_nvnCommandBufferUpdateUniformBuffer = (nvnCommandBufferUpdateUniformBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferUpdateUniformBuffer");
-    pfnc_nvnCommandBufferReportCounter = (nvnCommandBufferReportCounterFunction)deviceGetProcAddress(device, "nvnCommandBufferReportCounter");
-    pfnc_nvnCommandBufferResetCounter = (nvnCommandBufferResetCounterFunction)deviceGetProcAddress(device, "nvnCommandBufferResetCounter");
-    pfnc_nvnCommandBufferReportValue = (nvnCommandBufferReportValueFunction)deviceGetProcAddress(device, "nvnCommandBufferReportValue");
-    pfnc_nvnCommandBufferSetRenderEnable = (nvnCommandBufferSetRenderEnableFunction)deviceGetProcAddress(device, "nvnCommandBufferSetRenderEnable");
-    pfnc_nvnCommandBufferSetRenderEnableConditional = (nvnCommandBufferSetRenderEnableConditionalFunction)deviceGetProcAddress(device, "nvnCommandBufferSetRenderEnableConditional");
-    pfnc_nvnCommandBufferSetRenderTargets = (nvnCommandBufferSetRenderTargetsFunction)deviceGetProcAddress(device, "nvnCommandBufferSetRenderTargets");
-    pfnc_nvnCommandBufferDiscardColor = (nvnCommandBufferDiscardColorFunction)deviceGetProcAddress(device, "nvnCommandBufferDiscardColor");
-    pfnc_nvnCommandBufferDiscardDepthStencil = (nvnCommandBufferDiscardDepthStencilFunction)deviceGetProcAddress(device, "nvnCommandBufferDiscardDepthStencil");
-    pfnc_nvnCommandBufferDownsample = (nvnCommandBufferDownsampleFunction)deviceGetProcAddress(device, "nvnCommandBufferDownsample");
-    pfnc_nvnCommandBufferTiledDownsample = (nvnCommandBufferTiledDownsampleFunction)deviceGetProcAddress(device, "nvnCommandBufferTiledDownsample");
-    pfnc_nvnCommandBufferDownsampleTextureView = (nvnCommandBufferDownsampleTextureViewFunction)deviceGetProcAddress(device, "nvnCommandBufferDownsampleTextureView");
-    pfnc_nvnCommandBufferTiledDownsampleTextureView = (nvnCommandBufferTiledDownsampleTextureViewFunction)deviceGetProcAddress(device, "nvnCommandBufferTiledDownsampleTextureView");
-    pfnc_nvnCommandBufferBarrier = (nvnCommandBufferBarrierFunction)deviceGetProcAddress(device, "nvnCommandBufferBarrier");
-    pfnc_nvnCommandBufferWaitSync = (nvnCommandBufferWaitSyncFunction)deviceGetProcAddress(device, "nvnCommandBufferWaitSync");
-    pfnc_nvnCommandBufferFenceSync = (nvnCommandBufferFenceSyncFunction)deviceGetProcAddress(device, "nvnCommandBufferFenceSync");
-    pfnc_nvnCommandBufferSetTexturePool = (nvnCommandBufferSetTexturePoolFunction)deviceGetProcAddress(device, "nvnCommandBufferSetTexturePool");
-    pfnc_nvnCommandBufferSetSamplerPool = (nvnCommandBufferSetSamplerPoolFunction)deviceGetProcAddress(device, "nvnCommandBufferSetSamplerPool");
-    pfnc_nvnCommandBufferSetShaderScratchMemory = (nvnCommandBufferSetShaderScratchMemoryFunction)deviceGetProcAddress(device, "nvnCommandBufferSetShaderScratchMemory");
-    pfnc_nvnCommandBufferSaveZCullData = (nvnCommandBufferSaveZCullDataFunction)deviceGetProcAddress(device, "nvnCommandBufferSaveZCullData");
-    pfnc_nvnCommandBufferRestoreZCullData = (nvnCommandBufferRestoreZCullDataFunction)deviceGetProcAddress(device, "nvnCommandBufferRestoreZCullData");
-    pfnc_nvnCommandBufferSetCopyRowStride = (nvnCommandBufferSetCopyRowStrideFunction)deviceGetProcAddress(device, "nvnCommandBufferSetCopyRowStride");
-    pfnc_nvnCommandBufferSetCopyImageStride = (nvnCommandBufferSetCopyImageStrideFunction)deviceGetProcAddress(device, "nvnCommandBufferSetCopyImageStride");
-    pfnc_nvnCommandBufferGetCopyRowStride = (nvnCommandBufferGetCopyRowStrideFunction)deviceGetProcAddress(device, "nvnCommandBufferGetCopyRowStride");
-    pfnc_nvnCommandBufferGetCopyImageStride = (nvnCommandBufferGetCopyImageStrideFunction)deviceGetProcAddress(device, "nvnCommandBufferGetCopyImageStride");
-    pfnc_nvnCommandBufferDrawTexture = (nvnCommandBufferDrawTextureFunction)deviceGetProcAddress(device, "nvnCommandBufferDrawTexture");
-    pfnc_nvnProgramSetSubroutineLinkage = (nvnProgramSetSubroutineLinkageFunction)deviceGetProcAddress(device, "nvnProgramSetSubroutineLinkage");
-    pfnc_nvnCommandBufferSetProgramSubroutines = (nvnCommandBufferSetProgramSubroutinesFunction)deviceGetProcAddress(device, "nvnCommandBufferSetProgramSubroutines");
-    pfnc_nvnCommandBufferBindCoverageModulationTable = (nvnCommandBufferBindCoverageModulationTableFunction)deviceGetProcAddress(device, "nvnCommandBufferBindCoverageModulationTable");
-    pfnc_nvnCommandBufferResolveDepthBuffer = (nvnCommandBufferResolveDepthBufferFunction)deviceGetProcAddress(device, "nvnCommandBufferResolveDepthBuffer");
-    pfnc_nvnCommandBufferPushDebugGroupStatic = (nvnCommandBufferPushDebugGroupStaticFunction)deviceGetProcAddress(device, "nvnCommandBufferPushDebugGroupStatic");
-    pfnc_nvnCommandBufferPushDebugGroupDynamic = (nvnCommandBufferPushDebugGroupDynamicFunction)deviceGetProcAddress(device, "nvnCommandBufferPushDebugGroupDynamic");
-    pfnc_nvnCommandBufferPushDebugGroup = (nvnCommandBufferPushDebugGroupFunction)deviceGetProcAddress(device, "nvnCommandBufferPushDebugGroup");
-    pfnc_nvnCommandBufferPopDebugGroup = (nvnCommandBufferPopDebugGroupFunction)deviceGetProcAddress(device, "nvnCommandBufferPopDebugGroup");
-    pfnc_nvnCommandBufferPopDebugGroupId = (nvnCommandBufferPopDebugGroupIdFunction)deviceGetProcAddress(device, "nvnCommandBufferPopDebugGroupId");
-    pfnc_nvnCommandBufferInsertDebugMarkerStatic = (nvnCommandBufferInsertDebugMarkerStaticFunction)deviceGetProcAddress(device, "nvnCommandBufferInsertDebugMarkerStatic");
-    pfnc_nvnCommandBufferInsertDebugMarkerDynamic = (nvnCommandBufferInsertDebugMarkerDynamicFunction)deviceGetProcAddress(device, "nvnCommandBufferInsertDebugMarkerDynamic");
-    pfnc_nvnCommandBufferInsertDebugMarker = (nvnCommandBufferInsertDebugMarkerFunction)deviceGetProcAddress(device, "nvnCommandBufferInsertDebugMarker");
-    pfnc_nvnCommandBufferGetMemoryCallback = (nvnCommandBufferGetMemoryCallbackFunction)deviceGetProcAddress(device, "nvnCommandBufferGetMemoryCallback");
-    pfnc_nvnCommandBufferGetMemoryCallbackData = (nvnCommandBufferGetMemoryCallbackDataFunction)deviceGetProcAddress(device, "nvnCommandBufferGetMemoryCallbackData");
-    pfnc_nvnCommandBufferIsRecording = (nvnCommandBufferIsRecordingFunction)deviceGetProcAddress(device, "nvnCommandBufferIsRecording");
-    pfnc_nvnSyncInitialize = (nvnSyncInitializeFunction)deviceGetProcAddress(device, "nvnSyncInitialize");
+    pfnc_nvnBufferGetAddress =
+        (nvnBufferGetAddressFunction)deviceGetProcAddress(device, "nvnBufferGetAddress");
+    pfnc_nvnBufferFlushMappedRange = (nvnBufferFlushMappedRangeFunction)deviceGetProcAddress(
+        device, "nvnBufferFlushMappedRange");
+    pfnc_nvnBufferInvalidateMappedRange =
+        (nvnBufferInvalidateMappedRangeFunction)deviceGetProcAddress(
+            device, "nvnBufferInvalidateMappedRange");
+    pfnc_nvnBufferGetMemoryPool =
+        (nvnBufferGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnBufferGetMemoryPool");
+    pfnc_nvnBufferGetMemoryOffset =
+        (nvnBufferGetMemoryOffsetFunction)deviceGetProcAddress(device, "nvnBufferGetMemoryOffset");
+    pfnc_nvnBufferGetSize =
+        (nvnBufferGetSizeFunction)deviceGetProcAddress(device, "nvnBufferGetSize");
+    pfnc_nvnBufferGetDebugID =
+        (nvnBufferGetDebugIDFunction)deviceGetProcAddress(device, "nvnBufferGetDebugID");
+    pfnc_nvnTextureBuilderSetDevice = (nvnTextureBuilderSetDeviceFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetDevice");
+    pfnc_nvnTextureBuilderSetDefaults = (nvnTextureBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetDefaults");
+    pfnc_nvnTextureBuilderSetFlags = (nvnTextureBuilderSetFlagsFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetFlags");
+    pfnc_nvnTextureBuilderSetTarget = (nvnTextureBuilderSetTargetFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetTarget");
+    pfnc_nvnTextureBuilderSetWidth = (nvnTextureBuilderSetWidthFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetWidth");
+    pfnc_nvnTextureBuilderSetHeight = (nvnTextureBuilderSetHeightFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetHeight");
+    pfnc_nvnTextureBuilderSetDepth = (nvnTextureBuilderSetDepthFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetDepth");
+    pfnc_nvnTextureBuilderSetSize1D = (nvnTextureBuilderSetSize1DFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetSize1D");
+    pfnc_nvnTextureBuilderSetSize2D = (nvnTextureBuilderSetSize2DFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetSize2D");
+    pfnc_nvnTextureBuilderSetSize3D = (nvnTextureBuilderSetSize3DFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetSize3D");
+    pfnc_nvnTextureBuilderSetLevels = (nvnTextureBuilderSetLevelsFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetLevels");
+    pfnc_nvnTextureBuilderSetFormat = (nvnTextureBuilderSetFormatFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetFormat");
+    pfnc_nvnTextureBuilderSetSamples = (nvnTextureBuilderSetSamplesFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetSamples");
+    pfnc_nvnTextureBuilderSetSwizzle = (nvnTextureBuilderSetSwizzleFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetSwizzle");
+    pfnc_nvnTextureBuilderSetDepthStencilMode =
+        (nvnTextureBuilderSetDepthStencilModeFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderSetDepthStencilMode");
+    pfnc_nvnTextureBuilderGetStorageSize =
+        (nvnTextureBuilderGetStorageSizeFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetStorageSize");
+    pfnc_nvnTextureBuilderGetStorageAlignment =
+        (nvnTextureBuilderGetStorageAlignmentFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetStorageAlignment");
+    pfnc_nvnTextureBuilderSetStorage = (nvnTextureBuilderSetStorageFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetStorage");
+    pfnc_nvnTextureBuilderSetPackagedTextureData =
+        (nvnTextureBuilderSetPackagedTextureDataFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderSetPackagedTextureData");
+    pfnc_nvnTextureBuilderSetPackagedTextureLayout =
+        (nvnTextureBuilderSetPackagedTextureLayoutFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderSetPackagedTextureLayout");
+    pfnc_nvnTextureBuilderSetStride = (nvnTextureBuilderSetStrideFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderSetStride");
+    pfnc_nvnTextureBuilderSetGLTextureName =
+        (nvnTextureBuilderSetGLTextureNameFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderSetGLTextureName");
+    pfnc_nvnTextureBuilderGetStorageClass =
+        (nvnTextureBuilderGetStorageClassFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetStorageClass");
+    pfnc_nvnTextureBuilderGetFlags = (nvnTextureBuilderGetFlagsFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetFlags");
+    pfnc_nvnTextureBuilderGetTarget = (nvnTextureBuilderGetTargetFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetTarget");
+    pfnc_nvnTextureBuilderGetWidth = (nvnTextureBuilderGetWidthFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetWidth");
+    pfnc_nvnTextureBuilderGetHeight = (nvnTextureBuilderGetHeightFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetHeight");
+    pfnc_nvnTextureBuilderGetDepth = (nvnTextureBuilderGetDepthFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetDepth");
+    pfnc_nvnTextureBuilderGetLevels = (nvnTextureBuilderGetLevelsFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetLevels");
+    pfnc_nvnTextureBuilderGetFormat = (nvnTextureBuilderGetFormatFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetFormat");
+    pfnc_nvnTextureBuilderGetSamples = (nvnTextureBuilderGetSamplesFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetSamples");
+    pfnc_nvnTextureBuilderGetSwizzle = (nvnTextureBuilderGetSwizzleFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetSwizzle");
+    pfnc_nvnTextureBuilderGetDepthStencilMode =
+        (nvnTextureBuilderGetDepthStencilModeFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetDepthStencilMode");
+    pfnc_nvnTextureBuilderGetPackagedTextureData =
+        (nvnTextureBuilderGetPackagedTextureDataFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetPackagedTextureData");
+    pfnc_nvnTextureBuilderGetStride = (nvnTextureBuilderGetStrideFunction)deviceGetProcAddress(
+        device, "nvnTextureBuilderGetStride");
+    pfnc_nvnTextureBuilderGetSparseTileLayout =
+        (nvnTextureBuilderGetSparseTileLayoutFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetSparseTileLayout");
+    pfnc_nvnTextureBuilderGetGLTextureName =
+        (nvnTextureBuilderGetGLTextureNameFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetGLTextureName");
+    pfnc_nvnTextureBuilderGetZCullStorageSize =
+        (nvnTextureBuilderGetZCullStorageSizeFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetZCullStorageSize");
+    pfnc_nvnTextureBuilderGetMemoryPool =
+        (nvnTextureBuilderGetMemoryPoolFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetMemoryPool");
+    pfnc_nvnTextureBuilderGetMemoryOffset =
+        (nvnTextureBuilderGetMemoryOffsetFunction)deviceGetProcAddress(
+            device, "nvnTextureBuilderGetMemoryOffset");
+    pfnc_nvnTextureViewSetDefaults = (nvnTextureViewSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnTextureViewSetDefaults");
+    pfnc_nvnTextureViewSetLevels =
+        (nvnTextureViewSetLevelsFunction)deviceGetProcAddress(device, "nvnTextureViewSetLevels");
+    pfnc_nvnTextureViewSetLayers =
+        (nvnTextureViewSetLayersFunction)deviceGetProcAddress(device, "nvnTextureViewSetLayers");
+    pfnc_nvnTextureViewSetFormat =
+        (nvnTextureViewSetFormatFunction)deviceGetProcAddress(device, "nvnTextureViewSetFormat");
+    pfnc_nvnTextureViewSetSwizzle =
+        (nvnTextureViewSetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureViewSetSwizzle");
+    pfnc_nvnTextureViewSetDepthStencilMode =
+        (nvnTextureViewSetDepthStencilModeFunction)deviceGetProcAddress(
+            device, "nvnTextureViewSetDepthStencilMode");
+    pfnc_nvnTextureViewSetTarget =
+        (nvnTextureViewSetTargetFunction)deviceGetProcAddress(device, "nvnTextureViewSetTarget");
+    pfnc_nvnTextureViewGetLevels =
+        (nvnTextureViewGetLevelsFunction)deviceGetProcAddress(device, "nvnTextureViewGetLevels");
+    pfnc_nvnTextureViewGetLayers =
+        (nvnTextureViewGetLayersFunction)deviceGetProcAddress(device, "nvnTextureViewGetLayers");
+    pfnc_nvnTextureViewGetFormat =
+        (nvnTextureViewGetFormatFunction)deviceGetProcAddress(device, "nvnTextureViewGetFormat");
+    pfnc_nvnTextureViewGetSwizzle =
+        (nvnTextureViewGetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureViewGetSwizzle");
+    pfnc_nvnTextureViewGetDepthStencilMode =
+        (nvnTextureViewGetDepthStencilModeFunction)deviceGetProcAddress(
+            device, "nvnTextureViewGetDepthStencilMode");
+    pfnc_nvnTextureViewGetTarget =
+        (nvnTextureViewGetTargetFunction)deviceGetProcAddress(device, "nvnTextureViewGetTarget");
+    pfnc_nvnTextureViewCompare =
+        (nvnTextureViewCompareFunction)deviceGetProcAddress(device, "nvnTextureViewCompare");
+    pfnc_nvnTextureInitialize =
+        (nvnTextureInitializeFunction)deviceGetProcAddress(device, "nvnTextureInitialize");
+    pfnc_nvnTextureGetZCullStorageSize =
+        (nvnTextureGetZCullStorageSizeFunction)deviceGetProcAddress(
+            device, "nvnTextureGetZCullStorageSize");
+    pfnc_nvnTextureFinalize =
+        (nvnTextureFinalizeFunction)deviceGetProcAddress(device, "nvnTextureFinalize");
+    pfnc_nvnTextureSetDebugLabel =
+        (nvnTextureSetDebugLabelFunction)deviceGetProcAddress(device, "nvnTextureSetDebugLabel");
+    pfnc_nvnTextureGetStorageClass = (nvnTextureGetStorageClassFunction)deviceGetProcAddress(
+        device, "nvnTextureGetStorageClass");
+    pfnc_nvnTextureGetViewOffset =
+        (nvnTextureGetViewOffsetFunction)deviceGetProcAddress(device, "nvnTextureGetViewOffset");
+    pfnc_nvnTextureGetFlags =
+        (nvnTextureGetFlagsFunction)deviceGetProcAddress(device, "nvnTextureGetFlags");
+    pfnc_nvnTextureGetTarget =
+        (nvnTextureGetTargetFunction)deviceGetProcAddress(device, "nvnTextureGetTarget");
+    pfnc_nvnTextureGetWidth =
+        (nvnTextureGetWidthFunction)deviceGetProcAddress(device, "nvnTextureGetWidth");
+    pfnc_nvnTextureGetHeight =
+        (nvnTextureGetHeightFunction)deviceGetProcAddress(device, "nvnTextureGetHeight");
+    pfnc_nvnTextureGetDepth =
+        (nvnTextureGetDepthFunction)deviceGetProcAddress(device, "nvnTextureGetDepth");
+    pfnc_nvnTextureGetLevels =
+        (nvnTextureGetLevelsFunction)deviceGetProcAddress(device, "nvnTextureGetLevels");
+    pfnc_nvnTextureGetFormat =
+        (nvnTextureGetFormatFunction)deviceGetProcAddress(device, "nvnTextureGetFormat");
+    pfnc_nvnTextureGetSamples =
+        (nvnTextureGetSamplesFunction)deviceGetProcAddress(device, "nvnTextureGetSamples");
+    pfnc_nvnTextureGetSwizzle =
+        (nvnTextureGetSwizzleFunction)deviceGetProcAddress(device, "nvnTextureGetSwizzle");
+    pfnc_nvnTextureGetDepthStencilMode =
+        (nvnTextureGetDepthStencilModeFunction)deviceGetProcAddress(
+            device, "nvnTextureGetDepthStencilMode");
+    pfnc_nvnTextureGetStride =
+        (nvnTextureGetStrideFunction)deviceGetProcAddress(device, "nvnTextureGetStride");
+    pfnc_nvnTextureGetTextureAddress = (nvnTextureGetTextureAddressFunction)deviceGetProcAddress(
+        device, "nvnTextureGetTextureAddress");
+    pfnc_nvnTextureGetSparseTileLayout =
+        (nvnTextureGetSparseTileLayoutFunction)deviceGetProcAddress(
+            device, "nvnTextureGetSparseTileLayout");
+    pfnc_nvnTextureWriteTexels =
+        (nvnTextureWriteTexelsFunction)deviceGetProcAddress(device, "nvnTextureWriteTexels");
+    pfnc_nvnTextureWriteTexelsStrided = (nvnTextureWriteTexelsStridedFunction)deviceGetProcAddress(
+        device, "nvnTextureWriteTexelsStrided");
+    pfnc_nvnTextureReadTexels =
+        (nvnTextureReadTexelsFunction)deviceGetProcAddress(device, "nvnTextureReadTexels");
+    pfnc_nvnTextureReadTexelsStrided = (nvnTextureReadTexelsStridedFunction)deviceGetProcAddress(
+        device, "nvnTextureReadTexelsStrided");
+    pfnc_nvnTextureFlushTexels =
+        (nvnTextureFlushTexelsFunction)deviceGetProcAddress(device, "nvnTextureFlushTexels");
+    pfnc_nvnTextureInvalidateTexels = (nvnTextureInvalidateTexelsFunction)deviceGetProcAddress(
+        device, "nvnTextureInvalidateTexels");
+    pfnc_nvnTextureGetMemoryPool =
+        (nvnTextureGetMemoryPoolFunction)deviceGetProcAddress(device, "nvnTextureGetMemoryPool");
+    pfnc_nvnTextureGetMemoryOffset = (nvnTextureGetMemoryOffsetFunction)deviceGetProcAddress(
+        device, "nvnTextureGetMemoryOffset");
+    pfnc_nvnTextureGetStorageSize =
+        (nvnTextureGetStorageSizeFunction)deviceGetProcAddress(device, "nvnTextureGetStorageSize");
+    pfnc_nvnTextureCompare =
+        (nvnTextureCompareFunction)deviceGetProcAddress(device, "nvnTextureCompare");
+    pfnc_nvnTextureGetDebugID =
+        (nvnTextureGetDebugIDFunction)deviceGetProcAddress(device, "nvnTextureGetDebugID");
+    pfnc_nvnSamplerBuilderSetDevice = (nvnSamplerBuilderSetDeviceFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetDevice");
+    pfnc_nvnSamplerBuilderSetDefaults = (nvnSamplerBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetDefaults");
+    pfnc_nvnSamplerBuilderSetMinMagFilter =
+        (nvnSamplerBuilderSetMinMagFilterFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderSetMinMagFilter");
+    pfnc_nvnSamplerBuilderSetWrapMode = (nvnSamplerBuilderSetWrapModeFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetWrapMode");
+    pfnc_nvnSamplerBuilderSetLodClamp = (nvnSamplerBuilderSetLodClampFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetLodClamp");
+    pfnc_nvnSamplerBuilderSetLodBias = (nvnSamplerBuilderSetLodBiasFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetLodBias");
+    pfnc_nvnSamplerBuilderSetCompare = (nvnSamplerBuilderSetCompareFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetCompare");
+    pfnc_nvnSamplerBuilderSetBorderColor =
+        (nvnSamplerBuilderSetBorderColorFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderSetBorderColor");
+    pfnc_nvnSamplerBuilderSetBorderColori =
+        (nvnSamplerBuilderSetBorderColoriFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderSetBorderColori");
+    pfnc_nvnSamplerBuilderSetBorderColorui =
+        (nvnSamplerBuilderSetBorderColoruiFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderSetBorderColorui");
+    pfnc_nvnSamplerBuilderSetMaxAnisotropy =
+        (nvnSamplerBuilderSetMaxAnisotropyFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderSetMaxAnisotropy");
+    pfnc_nvnSamplerBuilderSetReductionFilter =
+        (nvnSamplerBuilderSetReductionFilterFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderSetReductionFilter");
+    pfnc_nvnSamplerBuilderSetLodSnap = (nvnSamplerBuilderSetLodSnapFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderSetLodSnap");
+    pfnc_nvnSamplerBuilderGetMinMagFilter =
+        (nvnSamplerBuilderGetMinMagFilterFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderGetMinMagFilter");
+    pfnc_nvnSamplerBuilderGetWrapMode = (nvnSamplerBuilderGetWrapModeFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderGetWrapMode");
+    pfnc_nvnSamplerBuilderGetLodClamp = (nvnSamplerBuilderGetLodClampFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderGetLodClamp");
+    pfnc_nvnSamplerBuilderGetLodBias = (nvnSamplerBuilderGetLodBiasFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderGetLodBias");
+    pfnc_nvnSamplerBuilderGetCompare = (nvnSamplerBuilderGetCompareFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderGetCompare");
+    pfnc_nvnSamplerBuilderGetBorderColor =
+        (nvnSamplerBuilderGetBorderColorFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderGetBorderColor");
+    pfnc_nvnSamplerBuilderGetBorderColori =
+        (nvnSamplerBuilderGetBorderColoriFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderGetBorderColori");
+    pfnc_nvnSamplerBuilderGetBorderColorui =
+        (nvnSamplerBuilderGetBorderColoruiFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderGetBorderColorui");
+    pfnc_nvnSamplerBuilderGetMaxAnisotropy =
+        (nvnSamplerBuilderGetMaxAnisotropyFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderGetMaxAnisotropy");
+    pfnc_nvnSamplerBuilderGetReductionFilter =
+        (nvnSamplerBuilderGetReductionFilterFunction)deviceGetProcAddress(
+            device, "nvnSamplerBuilderGetReductionFilter");
+    pfnc_nvnSamplerBuilderGetLodSnap = (nvnSamplerBuilderGetLodSnapFunction)deviceGetProcAddress(
+        device, "nvnSamplerBuilderGetLodSnap");
+    pfnc_nvnSamplerInitialize =
+        (nvnSamplerInitializeFunction)deviceGetProcAddress(device, "nvnSamplerInitialize");
+    pfnc_nvnSamplerFinalize =
+        (nvnSamplerFinalizeFunction)deviceGetProcAddress(device, "nvnSamplerFinalize");
+    pfnc_nvnSamplerSetDebugLabel =
+        (nvnSamplerSetDebugLabelFunction)deviceGetProcAddress(device, "nvnSamplerSetDebugLabel");
+    pfnc_nvnSamplerGetMinMagFilter = (nvnSamplerGetMinMagFilterFunction)deviceGetProcAddress(
+        device, "nvnSamplerGetMinMagFilter");
+    pfnc_nvnSamplerGetWrapMode =
+        (nvnSamplerGetWrapModeFunction)deviceGetProcAddress(device, "nvnSamplerGetWrapMode");
+    pfnc_nvnSamplerGetLodClamp =
+        (nvnSamplerGetLodClampFunction)deviceGetProcAddress(device, "nvnSamplerGetLodClamp");
+    pfnc_nvnSamplerGetLodBias =
+        (nvnSamplerGetLodBiasFunction)deviceGetProcAddress(device, "nvnSamplerGetLodBias");
+    pfnc_nvnSamplerGetCompare =
+        (nvnSamplerGetCompareFunction)deviceGetProcAddress(device, "nvnSamplerGetCompare");
+    pfnc_nvnSamplerGetBorderColor =
+        (nvnSamplerGetBorderColorFunction)deviceGetProcAddress(device, "nvnSamplerGetBorderColor");
+    pfnc_nvnSamplerGetBorderColori = (nvnSamplerGetBorderColoriFunction)deviceGetProcAddress(
+        device, "nvnSamplerGetBorderColori");
+    pfnc_nvnSamplerGetBorderColorui = (nvnSamplerGetBorderColoruiFunction)deviceGetProcAddress(
+        device, "nvnSamplerGetBorderColorui");
+    pfnc_nvnSamplerGetMaxAnisotropy = (nvnSamplerGetMaxAnisotropyFunction)deviceGetProcAddress(
+        device, "nvnSamplerGetMaxAnisotropy");
+    pfnc_nvnSamplerGetReductionFilter = (nvnSamplerGetReductionFilterFunction)deviceGetProcAddress(
+        device, "nvnSamplerGetReductionFilter");
+    pfnc_nvnSamplerCompare =
+        (nvnSamplerCompareFunction)deviceGetProcAddress(device, "nvnSamplerCompare");
+    pfnc_nvnSamplerGetDebugID =
+        (nvnSamplerGetDebugIDFunction)deviceGetProcAddress(device, "nvnSamplerGetDebugID");
+    pfnc_nvnBlendStateSetDefaults =
+        (nvnBlendStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnBlendStateSetDefaults");
+    pfnc_nvnBlendStateSetBlendTarget = (nvnBlendStateSetBlendTargetFunction)deviceGetProcAddress(
+        device, "nvnBlendStateSetBlendTarget");
+    pfnc_nvnBlendStateSetBlendFunc = (nvnBlendStateSetBlendFuncFunction)deviceGetProcAddress(
+        device, "nvnBlendStateSetBlendFunc");
+    pfnc_nvnBlendStateSetBlendEquation =
+        (nvnBlendStateSetBlendEquationFunction)deviceGetProcAddress(
+            device, "nvnBlendStateSetBlendEquation");
+    pfnc_nvnBlendStateSetAdvancedMode = (nvnBlendStateSetAdvancedModeFunction)deviceGetProcAddress(
+        device, "nvnBlendStateSetAdvancedMode");
+    pfnc_nvnBlendStateSetAdvancedOverlap =
+        (nvnBlendStateSetAdvancedOverlapFunction)deviceGetProcAddress(
+            device, "nvnBlendStateSetAdvancedOverlap");
+    pfnc_nvnBlendStateSetAdvancedPremultipliedSrc =
+        (nvnBlendStateSetAdvancedPremultipliedSrcFunction)deviceGetProcAddress(
+            device, "nvnBlendStateSetAdvancedPremultipliedSrc");
+    pfnc_nvnBlendStateSetAdvancedNormalizedDst =
+        (nvnBlendStateSetAdvancedNormalizedDstFunction)deviceGetProcAddress(
+            device, "nvnBlendStateSetAdvancedNormalizedDst");
+    pfnc_nvnBlendStateGetBlendTarget = (nvnBlendStateGetBlendTargetFunction)deviceGetProcAddress(
+        device, "nvnBlendStateGetBlendTarget");
+    pfnc_nvnBlendStateGetBlendFunc = (nvnBlendStateGetBlendFuncFunction)deviceGetProcAddress(
+        device, "nvnBlendStateGetBlendFunc");
+    pfnc_nvnBlendStateGetBlendEquation =
+        (nvnBlendStateGetBlendEquationFunction)deviceGetProcAddress(
+            device, "nvnBlendStateGetBlendEquation");
+    pfnc_nvnBlendStateGetAdvancedMode = (nvnBlendStateGetAdvancedModeFunction)deviceGetProcAddress(
+        device, "nvnBlendStateGetAdvancedMode");
+    pfnc_nvnBlendStateGetAdvancedOverlap =
+        (nvnBlendStateGetAdvancedOverlapFunction)deviceGetProcAddress(
+            device, "nvnBlendStateGetAdvancedOverlap");
+    pfnc_nvnBlendStateGetAdvancedPremultipliedSrc =
+        (nvnBlendStateGetAdvancedPremultipliedSrcFunction)deviceGetProcAddress(
+            device, "nvnBlendStateGetAdvancedPremultipliedSrc");
+    pfnc_nvnBlendStateGetAdvancedNormalizedDst =
+        (nvnBlendStateGetAdvancedNormalizedDstFunction)deviceGetProcAddress(
+            device, "nvnBlendStateGetAdvancedNormalizedDst");
+    pfnc_nvnColorStateSetDefaults =
+        (nvnColorStateSetDefaultsFunction)deviceGetProcAddress(device, "nvnColorStateSetDefaults");
+    pfnc_nvnColorStateSetBlendEnable = (nvnColorStateSetBlendEnableFunction)deviceGetProcAddress(
+        device, "nvnColorStateSetBlendEnable");
+    pfnc_nvnColorStateSetLogicOp =
+        (nvnColorStateSetLogicOpFunction)deviceGetProcAddress(device, "nvnColorStateSetLogicOp");
+    pfnc_nvnColorStateSetAlphaTest = (nvnColorStateSetAlphaTestFunction)deviceGetProcAddress(
+        device, "nvnColorStateSetAlphaTest");
+    pfnc_nvnColorStateGetBlendEnable = (nvnColorStateGetBlendEnableFunction)deviceGetProcAddress(
+        device, "nvnColorStateGetBlendEnable");
+    pfnc_nvnColorStateGetLogicOp =
+        (nvnColorStateGetLogicOpFunction)deviceGetProcAddress(device, "nvnColorStateGetLogicOp");
+    pfnc_nvnColorStateGetAlphaTest = (nvnColorStateGetAlphaTestFunction)deviceGetProcAddress(
+        device, "nvnColorStateGetAlphaTest");
+    pfnc_nvnChannelMaskStateSetDefaults =
+        (nvnChannelMaskStateSetDefaultsFunction)deviceGetProcAddress(
+            device, "nvnChannelMaskStateSetDefaults");
+    pfnc_nvnChannelMaskStateSetChannelMask =
+        (nvnChannelMaskStateSetChannelMaskFunction)deviceGetProcAddress(
+            device, "nvnChannelMaskStateSetChannelMask");
+    pfnc_nvnChannelMaskStateGetChannelMask =
+        (nvnChannelMaskStateGetChannelMaskFunction)deviceGetProcAddress(
+            device, "nvnChannelMaskStateGetChannelMask");
+    pfnc_nvnMultisampleStateSetDefaults =
+        (nvnMultisampleStateSetDefaultsFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetDefaults");
+    pfnc_nvnMultisampleStateSetMultisampleEnable =
+        (nvnMultisampleStateSetMultisampleEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetMultisampleEnable");
+    pfnc_nvnMultisampleStateSetSamples =
+        (nvnMultisampleStateSetSamplesFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetSamples");
+    pfnc_nvnMultisampleStateSetAlphaToCoverageEnable =
+        (nvnMultisampleStateSetAlphaToCoverageEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetAlphaToCoverageEnable");
+    pfnc_nvnMultisampleStateSetAlphaToCoverageDither =
+        (nvnMultisampleStateSetAlphaToCoverageDitherFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetAlphaToCoverageDither");
+    pfnc_nvnMultisampleStateGetMultisampleEnable =
+        (nvnMultisampleStateGetMultisampleEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetMultisampleEnable");
+    pfnc_nvnMultisampleStateGetSamples =
+        (nvnMultisampleStateGetSamplesFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetSamples");
+    pfnc_nvnMultisampleStateGetAlphaToCoverageEnable =
+        (nvnMultisampleStateGetAlphaToCoverageEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetAlphaToCoverageEnable");
+    pfnc_nvnMultisampleStateGetAlphaToCoverageDither =
+        (nvnMultisampleStateGetAlphaToCoverageDitherFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetAlphaToCoverageDither");
+    pfnc_nvnMultisampleStateSetRasterSamples =
+        (nvnMultisampleStateSetRasterSamplesFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetRasterSamples");
+    pfnc_nvnMultisampleStateGetRasterSamples =
+        (nvnMultisampleStateGetRasterSamplesFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetRasterSamples");
+    pfnc_nvnMultisampleStateSetCoverageModulationMode =
+        (nvnMultisampleStateSetCoverageModulationModeFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetCoverageModulationMode");
+    pfnc_nvnMultisampleStateGetCoverageModulationMode =
+        (nvnMultisampleStateGetCoverageModulationModeFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetCoverageModulationMode");
+    pfnc_nvnMultisampleStateSetCoverageToColorEnable =
+        (nvnMultisampleStateSetCoverageToColorEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetCoverageToColorEnable");
+    pfnc_nvnMultisampleStateGetCoverageToColorEnable =
+        (nvnMultisampleStateGetCoverageToColorEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetCoverageToColorEnable");
+    pfnc_nvnMultisampleStateSetCoverageToColorOutput =
+        (nvnMultisampleStateSetCoverageToColorOutputFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetCoverageToColorOutput");
+    pfnc_nvnMultisampleStateGetCoverageToColorOutput =
+        (nvnMultisampleStateGetCoverageToColorOutputFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetCoverageToColorOutput");
+    pfnc_nvnMultisampleStateSetSampleLocationsEnable =
+        (nvnMultisampleStateSetSampleLocationsEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetSampleLocationsEnable");
+    pfnc_nvnMultisampleStateGetSampleLocationsEnable =
+        (nvnMultisampleStateGetSampleLocationsEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetSampleLocationsEnable");
+    pfnc_nvnMultisampleStateGetSampleLocationsGrid =
+        (nvnMultisampleStateGetSampleLocationsGridFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetSampleLocationsGrid");
+    pfnc_nvnMultisampleStateSetSampleLocationsGridEnable =
+        (nvnMultisampleStateSetSampleLocationsGridEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetSampleLocationsGridEnable");
+    pfnc_nvnMultisampleStateGetSampleLocationsGridEnable =
+        (nvnMultisampleStateGetSampleLocationsGridEnableFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateGetSampleLocationsGridEnable");
+    pfnc_nvnMultisampleStateSetSampleLocations =
+        (nvnMultisampleStateSetSampleLocationsFunction)deviceGetProcAddress(
+            device, "nvnMultisampleStateSetSampleLocations");
+    pfnc_nvnPolygonStateSetDefaults = (nvnPolygonStateSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnPolygonStateSetDefaults");
+    pfnc_nvnPolygonStateSetCullFace = (nvnPolygonStateSetCullFaceFunction)deviceGetProcAddress(
+        device, "nvnPolygonStateSetCullFace");
+    pfnc_nvnPolygonStateSetFrontFace = (nvnPolygonStateSetFrontFaceFunction)deviceGetProcAddress(
+        device, "nvnPolygonStateSetFrontFace");
+    pfnc_nvnPolygonStateSetPolygonMode =
+        (nvnPolygonStateSetPolygonModeFunction)deviceGetProcAddress(
+            device, "nvnPolygonStateSetPolygonMode");
+    pfnc_nvnPolygonStateSetPolygonOffsetEnables =
+        (nvnPolygonStateSetPolygonOffsetEnablesFunction)deviceGetProcAddress(
+            device, "nvnPolygonStateSetPolygonOffsetEnables");
+    pfnc_nvnPolygonStateGetCullFace = (nvnPolygonStateGetCullFaceFunction)deviceGetProcAddress(
+        device, "nvnPolygonStateGetCullFace");
+    pfnc_nvnPolygonStateGetFrontFace = (nvnPolygonStateGetFrontFaceFunction)deviceGetProcAddress(
+        device, "nvnPolygonStateGetFrontFace");
+    pfnc_nvnPolygonStateGetPolygonMode =
+        (nvnPolygonStateGetPolygonModeFunction)deviceGetProcAddress(
+            device, "nvnPolygonStateGetPolygonMode");
+    pfnc_nvnPolygonStateGetPolygonOffsetEnables =
+        (nvnPolygonStateGetPolygonOffsetEnablesFunction)deviceGetProcAddress(
+            device, "nvnPolygonStateGetPolygonOffsetEnables");
+    pfnc_nvnDepthStencilStateSetDefaults =
+        (nvnDepthStencilStateSetDefaultsFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetDefaults");
+    pfnc_nvnDepthStencilStateSetDepthTestEnable =
+        (nvnDepthStencilStateSetDepthTestEnableFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetDepthTestEnable");
+    pfnc_nvnDepthStencilStateSetDepthWriteEnable =
+        (nvnDepthStencilStateSetDepthWriteEnableFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetDepthWriteEnable");
+    pfnc_nvnDepthStencilStateSetDepthFunc =
+        (nvnDepthStencilStateSetDepthFuncFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetDepthFunc");
+    pfnc_nvnDepthStencilStateSetStencilTestEnable =
+        (nvnDepthStencilStateSetStencilTestEnableFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetStencilTestEnable");
+    pfnc_nvnDepthStencilStateSetStencilFunc =
+        (nvnDepthStencilStateSetStencilFuncFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetStencilFunc");
+    pfnc_nvnDepthStencilStateSetStencilOp =
+        (nvnDepthStencilStateSetStencilOpFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateSetStencilOp");
+    pfnc_nvnDepthStencilStateGetDepthTestEnable =
+        (nvnDepthStencilStateGetDepthTestEnableFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateGetDepthTestEnable");
+    pfnc_nvnDepthStencilStateGetDepthWriteEnable =
+        (nvnDepthStencilStateGetDepthWriteEnableFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateGetDepthWriteEnable");
+    pfnc_nvnDepthStencilStateGetDepthFunc =
+        (nvnDepthStencilStateGetDepthFuncFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateGetDepthFunc");
+    pfnc_nvnDepthStencilStateGetStencilTestEnable =
+        (nvnDepthStencilStateGetStencilTestEnableFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateGetStencilTestEnable");
+    pfnc_nvnDepthStencilStateGetStencilFunc =
+        (nvnDepthStencilStateGetStencilFuncFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateGetStencilFunc");
+    pfnc_nvnDepthStencilStateGetStencilOp =
+        (nvnDepthStencilStateGetStencilOpFunction)deviceGetProcAddress(
+            device, "nvnDepthStencilStateGetStencilOp");
+    pfnc_nvnVertexAttribStateSetDefaults =
+        (nvnVertexAttribStateSetDefaultsFunction)deviceGetProcAddress(
+            device, "nvnVertexAttribStateSetDefaults");
+    pfnc_nvnVertexAttribStateSetFormat =
+        (nvnVertexAttribStateSetFormatFunction)deviceGetProcAddress(
+            device, "nvnVertexAttribStateSetFormat");
+    pfnc_nvnVertexAttribStateSetStreamIndex =
+        (nvnVertexAttribStateSetStreamIndexFunction)deviceGetProcAddress(
+            device, "nvnVertexAttribStateSetStreamIndex");
+    pfnc_nvnVertexAttribStateGetFormat =
+        (nvnVertexAttribStateGetFormatFunction)deviceGetProcAddress(
+            device, "nvnVertexAttribStateGetFormat");
+    pfnc_nvnVertexAttribStateGetStreamIndex =
+        (nvnVertexAttribStateGetStreamIndexFunction)deviceGetProcAddress(
+            device, "nvnVertexAttribStateGetStreamIndex");
+    pfnc_nvnVertexStreamStateSetDefaults =
+        (nvnVertexStreamStateSetDefaultsFunction)deviceGetProcAddress(
+            device, "nvnVertexStreamStateSetDefaults");
+    pfnc_nvnVertexStreamStateSetStride =
+        (nvnVertexStreamStateSetStrideFunction)deviceGetProcAddress(
+            device, "nvnVertexStreamStateSetStride");
+    pfnc_nvnVertexStreamStateSetDivisor =
+        (nvnVertexStreamStateSetDivisorFunction)deviceGetProcAddress(
+            device, "nvnVertexStreamStateSetDivisor");
+    pfnc_nvnVertexStreamStateGetStride =
+        (nvnVertexStreamStateGetStrideFunction)deviceGetProcAddress(
+            device, "nvnVertexStreamStateGetStride");
+    pfnc_nvnVertexStreamStateGetDivisor =
+        (nvnVertexStreamStateGetDivisorFunction)deviceGetProcAddress(
+            device, "nvnVertexStreamStateGetDivisor");
+    pfnc_nvnCommandBufferInitialize = (nvnCommandBufferInitializeFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferInitialize");
+    pfnc_nvnCommandBufferFinalize =
+        (nvnCommandBufferFinalizeFunction)deviceGetProcAddress(device, "nvnCommandBufferFinalize");
+    pfnc_nvnCommandBufferSetDebugLabel =
+        (nvnCommandBufferSetDebugLabelFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetDebugLabel");
+    pfnc_nvnCommandBufferSetMemoryCallback =
+        (nvnCommandBufferSetMemoryCallbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetMemoryCallback");
+    pfnc_nvnCommandBufferSetMemoryCallbackData =
+        (nvnCommandBufferSetMemoryCallbackDataFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetMemoryCallbackData");
+    pfnc_nvnCommandBufferAddCommandMemory =
+        (nvnCommandBufferAddCommandMemoryFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferAddCommandMemory");
+    pfnc_nvnCommandBufferAddControlMemory =
+        (nvnCommandBufferAddControlMemoryFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferAddControlMemory");
+    pfnc_nvnCommandBufferGetCommandMemorySize =
+        (nvnCommandBufferGetCommandMemorySizeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetCommandMemorySize");
+    pfnc_nvnCommandBufferGetCommandMemoryUsed =
+        (nvnCommandBufferGetCommandMemoryUsedFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetCommandMemoryUsed");
+    pfnc_nvnCommandBufferGetCommandMemoryFree =
+        (nvnCommandBufferGetCommandMemoryFreeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetCommandMemoryFree");
+    pfnc_nvnCommandBufferGetControlMemorySize =
+        (nvnCommandBufferGetControlMemorySizeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetControlMemorySize");
+    pfnc_nvnCommandBufferGetControlMemoryUsed =
+        (nvnCommandBufferGetControlMemoryUsedFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetControlMemoryUsed");
+    pfnc_nvnCommandBufferGetControlMemoryFree =
+        (nvnCommandBufferGetControlMemoryFreeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetControlMemoryFree");
+    pfnc_nvnCommandBufferBeginRecording =
+        (nvnCommandBufferBeginRecordingFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBeginRecording");
+    pfnc_nvnCommandBufferEndRecording = (nvnCommandBufferEndRecordingFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferEndRecording");
+    pfnc_nvnCommandBufferCallCommands = (nvnCommandBufferCallCommandsFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferCallCommands");
+    pfnc_nvnCommandBufferCopyCommands = (nvnCommandBufferCopyCommandsFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferCopyCommands");
+    pfnc_nvnCommandBufferBindBlendState =
+        (nvnCommandBufferBindBlendStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindBlendState");
+    pfnc_nvnCommandBufferBindChannelMaskState =
+        (nvnCommandBufferBindChannelMaskStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindChannelMaskState");
+    pfnc_nvnCommandBufferBindColorState =
+        (nvnCommandBufferBindColorStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindColorState");
+    pfnc_nvnCommandBufferBindMultisampleState =
+        (nvnCommandBufferBindMultisampleStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindMultisampleState");
+    pfnc_nvnCommandBufferBindPolygonState =
+        (nvnCommandBufferBindPolygonStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindPolygonState");
+    pfnc_nvnCommandBufferBindDepthStencilState =
+        (nvnCommandBufferBindDepthStencilStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindDepthStencilState");
+    pfnc_nvnCommandBufferBindVertexAttribState =
+        (nvnCommandBufferBindVertexAttribStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindVertexAttribState");
+    pfnc_nvnCommandBufferBindVertexStreamState =
+        (nvnCommandBufferBindVertexStreamStateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindVertexStreamState");
+    pfnc_nvnCommandBufferBindProgram = (nvnCommandBufferBindProgramFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferBindProgram");
+    pfnc_nvnCommandBufferBindVertexBuffer =
+        (nvnCommandBufferBindVertexBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindVertexBuffer");
+    pfnc_nvnCommandBufferBindVertexBuffers =
+        (nvnCommandBufferBindVertexBuffersFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindVertexBuffers");
+    pfnc_nvnCommandBufferBindUniformBuffer =
+        (nvnCommandBufferBindUniformBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindUniformBuffer");
+    pfnc_nvnCommandBufferBindUniformBuffers =
+        (nvnCommandBufferBindUniformBuffersFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindUniformBuffers");
+    pfnc_nvnCommandBufferBindTransformFeedbackBuffer =
+        (nvnCommandBufferBindTransformFeedbackBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindTransformFeedbackBuffer");
+    pfnc_nvnCommandBufferBindTransformFeedbackBuffers =
+        (nvnCommandBufferBindTransformFeedbackBuffersFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindTransformFeedbackBuffers");
+    pfnc_nvnCommandBufferBindStorageBuffer =
+        (nvnCommandBufferBindStorageBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindStorageBuffer");
+    pfnc_nvnCommandBufferBindStorageBuffers =
+        (nvnCommandBufferBindStorageBuffersFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindStorageBuffers");
+    pfnc_nvnCommandBufferBindTexture = (nvnCommandBufferBindTextureFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferBindTexture");
+    pfnc_nvnCommandBufferBindTextures = (nvnCommandBufferBindTexturesFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferBindTextures");
+    pfnc_nvnCommandBufferBindImage = (nvnCommandBufferBindImageFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferBindImage");
+    pfnc_nvnCommandBufferBindImages = (nvnCommandBufferBindImagesFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferBindImages");
+    pfnc_nvnCommandBufferSetPatchSize = (nvnCommandBufferSetPatchSizeFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetPatchSize");
+    pfnc_nvnCommandBufferSetInnerTessellationLevels =
+        (nvnCommandBufferSetInnerTessellationLevelsFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetInnerTessellationLevels");
+    pfnc_nvnCommandBufferSetOuterTessellationLevels =
+        (nvnCommandBufferSetOuterTessellationLevelsFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetOuterTessellationLevels");
+    pfnc_nvnCommandBufferSetPrimitiveRestart =
+        (nvnCommandBufferSetPrimitiveRestartFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetPrimitiveRestart");
+    pfnc_nvnCommandBufferBeginTransformFeedback =
+        (nvnCommandBufferBeginTransformFeedbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBeginTransformFeedback");
+    pfnc_nvnCommandBufferEndTransformFeedback =
+        (nvnCommandBufferEndTransformFeedbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferEndTransformFeedback");
+    pfnc_nvnCommandBufferPauseTransformFeedback =
+        (nvnCommandBufferPauseTransformFeedbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferPauseTransformFeedback");
+    pfnc_nvnCommandBufferResumeTransformFeedback =
+        (nvnCommandBufferResumeTransformFeedbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferResumeTransformFeedback");
+    pfnc_nvnCommandBufferDrawTransformFeedback =
+        (nvnCommandBufferDrawTransformFeedbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDrawTransformFeedback");
+    pfnc_nvnCommandBufferDrawArrays = (nvnCommandBufferDrawArraysFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferDrawArrays");
+    pfnc_nvnCommandBufferDrawElements = (nvnCommandBufferDrawElementsFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferDrawElements");
+    pfnc_nvnCommandBufferDrawElementsBaseVertex =
+        (nvnCommandBufferDrawElementsBaseVertexFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDrawElementsBaseVertex");
+    pfnc_nvnCommandBufferDrawArraysInstanced =
+        (nvnCommandBufferDrawArraysInstancedFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDrawArraysInstanced");
+    pfnc_nvnCommandBufferDrawElementsInstanced =
+        (nvnCommandBufferDrawElementsInstancedFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDrawElementsInstanced");
+    pfnc_nvnCommandBufferDrawArraysIndirect =
+        (nvnCommandBufferDrawArraysIndirectFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDrawArraysIndirect");
+    pfnc_nvnCommandBufferDrawElementsIndirect =
+        (nvnCommandBufferDrawElementsIndirectFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDrawElementsIndirect");
+    pfnc_nvnCommandBufferMultiDrawArraysIndirectCount =
+        (nvnCommandBufferMultiDrawArraysIndirectCountFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferMultiDrawArraysIndirectCount");
+    pfnc_nvnCommandBufferMultiDrawElementsIndirectCount =
+        (nvnCommandBufferMultiDrawElementsIndirectCountFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferMultiDrawElementsIndirectCount");
+    pfnc_nvnCommandBufferClearColor = (nvnCommandBufferClearColorFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferClearColor");
+    pfnc_nvnCommandBufferClearColori = (nvnCommandBufferClearColoriFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferClearColori");
+    pfnc_nvnCommandBufferClearColorui = (nvnCommandBufferClearColoruiFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferClearColorui");
+    pfnc_nvnCommandBufferClearDepthStencil =
+        (nvnCommandBufferClearDepthStencilFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferClearDepthStencil");
+    pfnc_nvnCommandBufferDispatchCompute =
+        (nvnCommandBufferDispatchComputeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDispatchCompute");
+    pfnc_nvnCommandBufferDispatchComputeIndirect =
+        (nvnCommandBufferDispatchComputeIndirectFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDispatchComputeIndirect");
+    pfnc_nvnCommandBufferSetViewport = (nvnCommandBufferSetViewportFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetViewport");
+    pfnc_nvnCommandBufferSetViewports = (nvnCommandBufferSetViewportsFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetViewports");
+    pfnc_nvnCommandBufferSetViewportSwizzles =
+        (nvnCommandBufferSetViewportSwizzlesFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetViewportSwizzles");
+    pfnc_nvnCommandBufferSetScissor = (nvnCommandBufferSetScissorFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetScissor");
+    pfnc_nvnCommandBufferSetScissors = (nvnCommandBufferSetScissorsFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetScissors");
+    pfnc_nvnCommandBufferSetDepthRange =
+        (nvnCommandBufferSetDepthRangeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetDepthRange");
+    pfnc_nvnCommandBufferSetDepthBounds =
+        (nvnCommandBufferSetDepthBoundsFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetDepthBounds");
+    pfnc_nvnCommandBufferSetDepthRanges =
+        (nvnCommandBufferSetDepthRangesFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetDepthRanges");
+    pfnc_nvnCommandBufferSetTiledCacheAction =
+        (nvnCommandBufferSetTiledCacheActionFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetTiledCacheAction");
+    pfnc_nvnCommandBufferSetTiledCacheTileSize =
+        (nvnCommandBufferSetTiledCacheTileSizeFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetTiledCacheTileSize");
+    pfnc_nvnCommandBufferBindSeparateTexture =
+        (nvnCommandBufferBindSeparateTextureFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindSeparateTexture");
+    pfnc_nvnCommandBufferBindSeparateSampler =
+        (nvnCommandBufferBindSeparateSamplerFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindSeparateSampler");
+    pfnc_nvnCommandBufferBindSeparateTextures =
+        (nvnCommandBufferBindSeparateTexturesFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindSeparateTextures");
+    pfnc_nvnCommandBufferBindSeparateSamplers =
+        (nvnCommandBufferBindSeparateSamplersFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindSeparateSamplers");
+    pfnc_nvnCommandBufferSetStencilValueMask =
+        (nvnCommandBufferSetStencilValueMaskFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetStencilValueMask");
+    pfnc_nvnCommandBufferSetStencilMask =
+        (nvnCommandBufferSetStencilMaskFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetStencilMask");
+    pfnc_nvnCommandBufferSetStencilRef =
+        (nvnCommandBufferSetStencilRefFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetStencilRef");
+    pfnc_nvnCommandBufferSetBlendColor =
+        (nvnCommandBufferSetBlendColorFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetBlendColor");
+    pfnc_nvnCommandBufferSetPointSize = (nvnCommandBufferSetPointSizeFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetPointSize");
+    pfnc_nvnCommandBufferSetLineWidth = (nvnCommandBufferSetLineWidthFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetLineWidth");
+    pfnc_nvnCommandBufferSetPolygonOffsetClamp =
+        (nvnCommandBufferSetPolygonOffsetClampFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetPolygonOffsetClamp");
+    pfnc_nvnCommandBufferSetAlphaRef = (nvnCommandBufferSetAlphaRefFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSetAlphaRef");
+    pfnc_nvnCommandBufferSetSampleMask =
+        (nvnCommandBufferSetSampleMaskFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetSampleMask");
+    pfnc_nvnCommandBufferSetRasterizerDiscard =
+        (nvnCommandBufferSetRasterizerDiscardFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetRasterizerDiscard");
+    pfnc_nvnCommandBufferSetDepthClamp =
+        (nvnCommandBufferSetDepthClampFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetDepthClamp");
+    pfnc_nvnCommandBufferSetConservativeRasterEnable =
+        (nvnCommandBufferSetConservativeRasterEnableFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetConservativeRasterEnable");
+    pfnc_nvnCommandBufferSetConservativeRasterDilate =
+        (nvnCommandBufferSetConservativeRasterDilateFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetConservativeRasterDilate");
+    pfnc_nvnCommandBufferSetSubpixelPrecisionBias =
+        (nvnCommandBufferSetSubpixelPrecisionBiasFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetSubpixelPrecisionBias");
+    pfnc_nvnCommandBufferCopyBufferToTexture =
+        (nvnCommandBufferCopyBufferToTextureFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferCopyBufferToTexture");
+    pfnc_nvnCommandBufferCopyTextureToBuffer =
+        (nvnCommandBufferCopyTextureToBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferCopyTextureToBuffer");
+    pfnc_nvnCommandBufferCopyTextureToTexture =
+        (nvnCommandBufferCopyTextureToTextureFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferCopyTextureToTexture");
+    pfnc_nvnCommandBufferCopyBufferToBuffer =
+        (nvnCommandBufferCopyBufferToBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferCopyBufferToBuffer");
+    pfnc_nvnCommandBufferClearBuffer = (nvnCommandBufferClearBufferFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferClearBuffer");
+    pfnc_nvnCommandBufferClearTexture = (nvnCommandBufferClearTextureFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferClearTexture");
+    pfnc_nvnCommandBufferClearTexturei =
+        (nvnCommandBufferClearTextureiFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferClearTexturei");
+    pfnc_nvnCommandBufferClearTextureui =
+        (nvnCommandBufferClearTextureuiFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferClearTextureui");
+    pfnc_nvnCommandBufferUpdateUniformBuffer =
+        (nvnCommandBufferUpdateUniformBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferUpdateUniformBuffer");
+    pfnc_nvnCommandBufferReportCounter =
+        (nvnCommandBufferReportCounterFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferReportCounter");
+    pfnc_nvnCommandBufferResetCounter = (nvnCommandBufferResetCounterFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferResetCounter");
+    pfnc_nvnCommandBufferReportValue = (nvnCommandBufferReportValueFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferReportValue");
+    pfnc_nvnCommandBufferSetRenderEnable =
+        (nvnCommandBufferSetRenderEnableFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetRenderEnable");
+    pfnc_nvnCommandBufferSetRenderEnableConditional =
+        (nvnCommandBufferSetRenderEnableConditionalFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetRenderEnableConditional");
+    pfnc_nvnCommandBufferSetRenderTargets =
+        (nvnCommandBufferSetRenderTargetsFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetRenderTargets");
+    pfnc_nvnCommandBufferDiscardColor = (nvnCommandBufferDiscardColorFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferDiscardColor");
+    pfnc_nvnCommandBufferDiscardDepthStencil =
+        (nvnCommandBufferDiscardDepthStencilFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDiscardDepthStencil");
+    pfnc_nvnCommandBufferDownsample = (nvnCommandBufferDownsampleFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferDownsample");
+    pfnc_nvnCommandBufferTiledDownsample =
+        (nvnCommandBufferTiledDownsampleFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferTiledDownsample");
+    pfnc_nvnCommandBufferDownsampleTextureView =
+        (nvnCommandBufferDownsampleTextureViewFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferDownsampleTextureView");
+    pfnc_nvnCommandBufferTiledDownsampleTextureView =
+        (nvnCommandBufferTiledDownsampleTextureViewFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferTiledDownsampleTextureView");
+    pfnc_nvnCommandBufferBarrier =
+        (nvnCommandBufferBarrierFunction)deviceGetProcAddress(device, "nvnCommandBufferBarrier");
+    pfnc_nvnCommandBufferWaitSync =
+        (nvnCommandBufferWaitSyncFunction)deviceGetProcAddress(device, "nvnCommandBufferWaitSync");
+    pfnc_nvnCommandBufferFenceSync = (nvnCommandBufferFenceSyncFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferFenceSync");
+    pfnc_nvnCommandBufferSetTexturePool =
+        (nvnCommandBufferSetTexturePoolFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetTexturePool");
+    pfnc_nvnCommandBufferSetSamplerPool =
+        (nvnCommandBufferSetSamplerPoolFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetSamplerPool");
+    pfnc_nvnCommandBufferSetShaderScratchMemory =
+        (nvnCommandBufferSetShaderScratchMemoryFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetShaderScratchMemory");
+    pfnc_nvnCommandBufferSaveZCullData =
+        (nvnCommandBufferSaveZCullDataFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSaveZCullData");
+    pfnc_nvnCommandBufferRestoreZCullData =
+        (nvnCommandBufferRestoreZCullDataFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferRestoreZCullData");
+    pfnc_nvnCommandBufferSetCopyRowStride =
+        (nvnCommandBufferSetCopyRowStrideFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetCopyRowStride");
+    pfnc_nvnCommandBufferSetCopyImageStride =
+        (nvnCommandBufferSetCopyImageStrideFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetCopyImageStride");
+    pfnc_nvnCommandBufferGetCopyRowStride =
+        (nvnCommandBufferGetCopyRowStrideFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetCopyRowStride");
+    pfnc_nvnCommandBufferGetCopyImageStride =
+        (nvnCommandBufferGetCopyImageStrideFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetCopyImageStride");
+    pfnc_nvnCommandBufferDrawTexture = (nvnCommandBufferDrawTextureFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferDrawTexture");
+    pfnc_nvnProgramSetSubroutineLinkage =
+        (nvnProgramSetSubroutineLinkageFunction)deviceGetProcAddress(
+            device, "nvnProgramSetSubroutineLinkage");
+    pfnc_nvnCommandBufferSetProgramSubroutines =
+        (nvnCommandBufferSetProgramSubroutinesFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferSetProgramSubroutines");
+    pfnc_nvnCommandBufferBindCoverageModulationTable =
+        (nvnCommandBufferBindCoverageModulationTableFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferBindCoverageModulationTable");
+    pfnc_nvnCommandBufferResolveDepthBuffer =
+        (nvnCommandBufferResolveDepthBufferFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferResolveDepthBuffer");
+    pfnc_nvnCommandBufferPushDebugGroupStatic =
+        (nvnCommandBufferPushDebugGroupStaticFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferPushDebugGroupStatic");
+    pfnc_nvnCommandBufferPushDebugGroupDynamic =
+        (nvnCommandBufferPushDebugGroupDynamicFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferPushDebugGroupDynamic");
+    pfnc_nvnCommandBufferPushDebugGroup =
+        (nvnCommandBufferPushDebugGroupFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferPushDebugGroup");
+    pfnc_nvnCommandBufferPopDebugGroup =
+        (nvnCommandBufferPopDebugGroupFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferPopDebugGroup");
+    pfnc_nvnCommandBufferPopDebugGroupId =
+        (nvnCommandBufferPopDebugGroupIdFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferPopDebugGroupId");
+    pfnc_nvnCommandBufferInsertDebugMarkerStatic =
+        (nvnCommandBufferInsertDebugMarkerStaticFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferInsertDebugMarkerStatic");
+    pfnc_nvnCommandBufferInsertDebugMarkerDynamic =
+        (nvnCommandBufferInsertDebugMarkerDynamicFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferInsertDebugMarkerDynamic");
+    pfnc_nvnCommandBufferInsertDebugMarker =
+        (nvnCommandBufferInsertDebugMarkerFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferInsertDebugMarker");
+    pfnc_nvnCommandBufferGetMemoryCallback =
+        (nvnCommandBufferGetMemoryCallbackFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetMemoryCallback");
+    pfnc_nvnCommandBufferGetMemoryCallbackData =
+        (nvnCommandBufferGetMemoryCallbackDataFunction)deviceGetProcAddress(
+            device, "nvnCommandBufferGetMemoryCallbackData");
+    pfnc_nvnCommandBufferIsRecording = (nvnCommandBufferIsRecordingFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferIsRecording");
+    pfnc_nvnSyncInitialize =
+        (nvnSyncInitializeFunction)deviceGetProcAddress(device, "nvnSyncInitialize");
     pfnc_nvnSyncFinalize = (nvnSyncFinalizeFunction)deviceGetProcAddress(device, "nvnSyncFinalize");
-    pfnc_nvnSyncSetDebugLabel = (nvnSyncSetDebugLabelFunction)deviceGetProcAddress(device, "nvnSyncSetDebugLabel");
-    pfnc_nvnQueueFenceSync = (nvnQueueFenceSyncFunction)deviceGetProcAddress(device, "nvnQueueFenceSync");
+    pfnc_nvnSyncSetDebugLabel =
+        (nvnSyncSetDebugLabelFunction)deviceGetProcAddress(device, "nvnSyncSetDebugLabel");
+    pfnc_nvnQueueFenceSync =
+        (nvnQueueFenceSyncFunction)deviceGetProcAddress(device, "nvnQueueFenceSync");
     pfnc_nvnSyncWait = (nvnSyncWaitFunction)deviceGetProcAddress(device, "nvnSyncWait");
-    pfnc_nvnQueueWaitSync = (nvnQueueWaitSyncFunction)deviceGetProcAddress(device, "nvnQueueWaitSync");
-    pfnc_nvnEventBuilderSetDefaults = (nvnEventBuilderSetDefaultsFunction)deviceGetProcAddress(device, "nvnEventBuilderSetDefaults");
-    pfnc_nvnEventBuilderSetStorage = (nvnEventBuilderSetStorageFunction)deviceGetProcAddress(device, "nvnEventBuilderSetStorage");
-    pfnc_nvnEventInitialize = (nvnEventInitializeFunction)deviceGetProcAddress(device, "nvnEventInitialize");
-    pfnc_nvnEventFinalize = (nvnEventFinalizeFunction)deviceGetProcAddress(device, "nvnEventFinalize");
-    pfnc_nvnEventGetValue = (nvnEventGetValueFunction)deviceGetProcAddress(device, "nvnEventGetValue");
+    pfnc_nvnQueueWaitSync =
+        (nvnQueueWaitSyncFunction)deviceGetProcAddress(device, "nvnQueueWaitSync");
+    pfnc_nvnEventBuilderSetDefaults = (nvnEventBuilderSetDefaultsFunction)deviceGetProcAddress(
+        device, "nvnEventBuilderSetDefaults");
+    pfnc_nvnEventBuilderSetStorage = (nvnEventBuilderSetStorageFunction)deviceGetProcAddress(
+        device, "nvnEventBuilderSetStorage");
+    pfnc_nvnEventInitialize =
+        (nvnEventInitializeFunction)deviceGetProcAddress(device, "nvnEventInitialize");
+    pfnc_nvnEventFinalize =
+        (nvnEventFinalizeFunction)deviceGetProcAddress(device, "nvnEventFinalize");
+    pfnc_nvnEventGetValue =
+        (nvnEventGetValueFunction)deviceGetProcAddress(device, "nvnEventGetValue");
     pfnc_nvnEventSignal = (nvnEventSignalFunction)deviceGetProcAddress(device, "nvnEventSignal");
-    pfnc_nvnCommandBufferWaitEvent = (nvnCommandBufferWaitEventFunction)deviceGetProcAddress(device, "nvnCommandBufferWaitEvent");
-    pfnc_nvnCommandBufferSignalEvent = (nvnCommandBufferSignalEventFunction)deviceGetProcAddress(device, "nvnCommandBufferSignalEvent");
+    pfnc_nvnCommandBufferWaitEvent = (nvnCommandBufferWaitEventFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferWaitEvent");
+    pfnc_nvnCommandBufferSignalEvent = (nvnCommandBufferSignalEventFunction)deviceGetProcAddress(
+        device, "nvnCommandBufferSignalEvent");
 }
 }


### PR DESCRIPTION
All `#include` statements are now in the form of `<nn/...>` instead of using relative paths.

Additionally, BindFuncTable was added. It was missing so far.

Finally, two `FIXME` tags were added for broken references or a wrong project structure. These are:
1. `nn/nex/socket.h` refers to `<arpa/inet.h>`, which requires `musl` to be set up properly.
2. `nn/ui2d/Pane.h` refers to `sead/runtime.h`, which does not conform the layers of this Library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/3)
<!-- Reviewable:end -->
