### PR TITLE
Additional nn::os, nn::sf and nn::vi definitions

### DIFF
--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -12,6 +12,7 @@
 
 namespace nn {
 namespace os {
+
 namespace detail {
 struct InternalCriticalSection {
     u32 Image;
@@ -19,6 +20,22 @@ struct InternalCriticalSection {
 
 struct InternalConditionVariable {
     u32 Image;
+};
+
+struct InterProcessEventType {
+    enum State {
+        State_NotInitialized = 0,
+        State_Initialized = 1,
+    };
+
+    nn::os::detail::InterProcessEventType* _x0;
+    nn::os::detail::InterProcessEventType* _x8;
+    bool shouldAutoClear;
+    u8 state;
+    bool isReadableHandleManaged;
+    bool isWritableHandleManaged;
+    u32 readableHandle;
+    u32 writableHandle;
 };
 }  // namespace detail
 
@@ -96,7 +113,19 @@ struct SemaphoreType {
 };
 
 struct SystemEvent;
-struct SystemEventType;
+struct SystemEventType {
+    enum State {
+        State_NotInitialized = 0,
+        State_InitializedAsEvent = 1,
+        State_InitializedAsInterProcessEvent = 2,
+    };
+
+    union {
+        nn::os::EventType event;
+        nn::os::detail::InterProcessEventType interProcessEvent;
+    };
+    u8 state;
+};
 
 // ARG
 void SetHostArgc(s32);

--- a/include/nn/sf.h
+++ b/include/nn/sf.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <nn/sf/hipc.h>
+#include <nn/svc.h>
+
+namespace nn {
+namespace sf {
+namespace detail {
+class PointerAndSize {
+public:
+    constexpr PointerAndSize() : pointer(nullptr), size(0) {}
+    constexpr PointerAndSize(void* ptr, size_t sz) : pointer(ptr), size(sz) {}
+
+    void* pointer;
+    size_t size;
+};
+}  // namespace detail
+
+template <typename A, typename B>
+class Out {
+public:
+    constexpr Out(A& p) : data{&p} {}
+    constexpr A& GetData() { return *data; };
+
+    A* data;
+};
+
+class OutBuffer {
+public:
+    constexpr OutBuffer() : buffer() {}
+    constexpr OutBuffer(const detail::PointerAndSize& buf) : buffer(buf) {}
+    constexpr OutBuffer(void* ptr, size_t sz) : buffer(ptr, sz) {}
+
+    detail::PointerAndSize buffer;
+};
+
+class InBuffer {
+public:
+    constexpr InBuffer() : buffer() {}
+    constexpr InBuffer(const detail::PointerAndSize& buf) : buffer(buf) {}
+    constexpr InBuffer(void* ptr, size_t sz) : buffer(ptr, sz) {}
+
+    detail::PointerAndSize buffer;
+};
+}  // namespace sf
+}  // namespace nn

--- a/include/nn/vi.h
+++ b/include/nn/vi.h
@@ -5,36 +5,115 @@
 
 #pragma once
 
+#include <nn/os.h>
 #include <nn/types.h>
 
 namespace nn {
-
-namespace os {
-struct SystemEventType;
-}
-
 namespace vi {
+
+enum LayerStack {
+    Default = 0,
+    Lcd = 1,
+    Screenshot = 2,
+    Recording = 3,
+    LastFrame = 4,
+    Arbitrary = 5,
+    ApplicationForDebug = 6,
+    Null = 10,
+};
+
+struct DisplayName {
+    static constexpr u32 maxNameLen = 64;
+    char data[maxNameLen];
+};
+
+struct DisplayInfo {
+    DisplayName name;
+    bool hasLayerLimit;
+    s64 maxLayers;
+    s64 maxWidth;
+    s64 maxHeight;
+};
+
+// Needs to be >128 bits, nnsdk uses X8 (indirect result register)
+struct IDisplayService {
+    uintptr_t servicePtr;
+    uintptr_t _x8[5];
+};
+
+typedef IDisplayService IManagerDisplayService;
+typedef IDisplayService ISystemDisplayService;
+
 class Display;
 class Layer;
-class NativWindow;
-struct DisplayInfo {
-    static const int maxNameLen = 64;
-    char name[maxNameLen];
-    bool hasLayerLimit;
-    int64_t maxLayers;
-    int64_t maxWidth;
-    int64_t maxHeight;
+class NativeWindow;
+
+struct LayerCreationSettings {
+    LayerCreationSettings(void);
+    LayerCreationSettings(s32 width, s32 height);
+    s32 GetWidth(void) const;
+    void SetWidth(s32 width);
+    s32 GetHeight(void) const;
+    void SetHeight(s32 height);
+    void SetFullscreen(bool isFullscreen);
+    bool IsFullscreen(void) const;
+    void SetVisibility(bool isVisible);
+    bool IsVisible(void) const;
+
+private:
+    s32 width;
+    s32 height;
+
+    union {
+        u32 rawFlags;
+        struct {
+            bool fullScreen : 1;  // defaults to false
+            bool visible : 1;     // defaults to true
+        };
+    };
 };
 
 enum ScalingMode { None, Exact, FitLayer, ScaleAndCrop, PreserveAspectRatio };
 
 void Initialize();
-Result OpenDefaultDisplay(nn::vi::Display** outDisp);
-Result CreateLayer(nn::vi::Layer** outLayer, nn::vi::Display* disp);
-Result SetLayerScalingMode(nn::vi::Layer* layer, nn::vi::ScalingMode scalingMode);
-Result GetDisplayVsyncEvent(nn::os::SystemEventType*, nn::vi::Display*);
-Result GetNativeWindow(void** window, nn::vi::Layer*);
+void InitializeMinimum();
+void Finalize();
+void FinalizeMinimum();
+
+IDisplayService GetService();
+ISystemDisplayService GetSystemService();
+IManagerDisplayService GetManagerService();
+
+Result SetContentVisibility(bool visibility);
+Result ListDisplays(nn::vi::DisplayInfo* outInfo, int count);
+Result OpenDefaultDisplay(nn::vi::Display** outDisplay);
+Result OpenDisplay(nn::vi::Display** outDisplay, const char* displayName);
+Result CloseDisplay(nn::vi::Display* inDisplay);
+Result GetDisplayVsyncEvent(nn::os::SystemEventType* outEvent, nn::vi::Display* inDisplay);
+s32 GetZOrderCountMin(const nn::vi::Display* inDisplay);
+s32 GetZOrderCountMax(const nn::vi::Display* inDisplay);
+Result GetDisplayLogicalResolution(s32* width, s32* height, const nn::vi::Display* inDisplay);
+Result GetDisplayResolution(s32* width, s32* height, const nn::vi::Display* inDisplay);
+u64 GetDisplayIdWithValidation(const nn::vi::Display* inDisplay);
 Result GetLatestFrameNumber(u64* pOutFrameNumber, const Layer* pLayer);
-int ListDisplays(DisplayInfo* outDisplays, int count);
+
+Result CreateLayer(nn::vi::Layer** outLayer, nn::vi::Display* inDisplay);
+Result CreateLayer(nn::vi::Layer** outLayer, nn::vi::Display* inDisplay,
+                   const nn::vi::LayerCreationSettings* inSettings);
+Result CreateLayer(nn::vi::Layer** outLayer, nn::vi::Display* inDisplay, s32 width, s32 height);
+void DestroyLayer(nn::vi::Layer* inLayer);
+Result GetNativeWindow(void** outWindow, nn::vi::Layer* inLayer);
+
+Result SetLayerScalingMode(nn::vi::Layer* layer, nn::vi::ScalingMode scalingMode);
+Result SetLayerPosition(nn::vi::Layer* inLayer, float x, float y);
+Result SetLayerSize(nn::vi::Layer* inLayer, s32 width, s32 height);
+Result SetLayerZ(nn::vi::Layer* inLayer, s32 z);
+Result GetLayerZ(s32* z, const nn::vi::Layer* inLayer);
+Result SetLayerVisibility(nn::vi::Layer* inLayer, bool isVisible);
+Result SetLayerAlpha(nn::vi::Layer* inLayer, float alpha);
+
+Result AddToLayerStack(nn::vi::Layer* inLayer, nn::vi::LayerStack layerStackType);
+Result RemoveFromLayerStack(nn::vi::Layer* inLayer, nn::vi::LayerStack layerStackType);
+u64 GetLayerIdWithValidation(const nn::vi::Layer* inLayer);
 }  // namespace vi
 }  // namespace nn


### PR DESCRIPTION
This pull request adds various extra definitions to nn::os and nn::vi, making them more complete.

UPDATE Sept 1st:
Added additional nn::sf types, needed for calling sdk functions that don't have pre-built wrappers in nnsdk (e.g. nn::vi::CreateManagedLayer)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/10)
<!-- Reviewable:end -->
