### PR TITLE
Fix NVN cpp types

### DIFF
--- a/include/nvn/nvn_Cpp.h
+++ b/include/nvn/nvn_Cpp.h
@@ -1119,7 +1119,7 @@ struct BufferRange {
     uint64_t size;
 };
 
-//forward declarations of nvn types
+// forward declarations of nvn types
 class CommandBuffer;
 class Window;
 class WindowBuilder;

--- a/include/nvn/nvn_Cpp.h
+++ b/include/nvn/nvn_Cpp.h
@@ -1119,6 +1119,30 @@ struct BufferRange {
     uint64_t size;
 };
 
+//forward declarations of nvn types
+class CommandBuffer;
+class Window;
+class WindowBuilder;
+class Sync;
+class MemoryPool;
+class BlendState;
+class ChannelMaskState;
+class ColorState;
+class MultisampleState;
+class PolygonState;
+class DepthStencilState;
+class VertexAttribState;
+class VertexStreamState;
+class Program;
+class Texture;
+class TextureBuilder;
+class TextureView;
+class TexturePool;
+class Sampler;
+class SamplerBuilder;
+class SamplerPool;
+class Event;
+
 typedef void (*GenericFuncPtrFunc)(void);
 typedef void (*DebugCallbackFunc)(DebugCallbackSource::Enum, DebugCallbackType::Enum, int,
                                   DebugCallbackSeverity::Enum, const char*, void*);

--- a/include/nvn/nvn_CppMethods.h
+++ b/include/nvn/nvn_CppMethods.h
@@ -1517,7 +1517,7 @@ inline void Buffer::Finalize() {
 }
 
 inline void* Buffer::Map() const {
-    pfncpp_nvnBufferMap(this);
+    return pfncpp_nvnBufferMap(this);
 }
 
 inline BufferAddress Buffer::GetAddress() const {


### PR DESCRIPTION
There are type errors when trying to include `nvn_Cpp.h`; forward declaring the types fixes these errors. 
Also, `Buffer::Map` had no return statement. This PR fixes both of these issues, making the Cpp NVN API usable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/17)
<!-- Reviewable:end -->
