### PR TITLE
nvnBootstrapLoader is a C function

### DIFF
--- a/include/nvn/nvn_CppFuncPtrBase.h
+++ b/include/nvn/nvn_CppFuncPtrBase.h
@@ -3,7 +3,7 @@
 #include <nvn/nvn_Cpp.h>
 
 // todo: figure out where to put this
-nvn::GenericFuncPtrFunc nvnBootstrapLoader(const char*);
+extern "C" nvn::GenericFuncPtrFunc nvnBootstrapLoader(const char*);
 
 namespace nvn {
 


### PR DESCRIPTION
nvnBootstrapLoader is treated as a C++ function in nvn_CppFuncPtrBase.h. This PR fixes this issue using `extern "C"`, forcing it to link as a C function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/21)
<!-- Reviewable:end -->
