### PR TITLE
fix nn::mem::StandardAllocator class

### DIFF
--- a/include/nn/mem.h
+++ b/include/nn/mem.h
@@ -20,8 +20,8 @@ namespace mem {
 class StandardAllocator {
 public:
     StandardAllocator();
-    StandardAllocator(void*, u64);
-    StandardAllocator(void*, u64, bool);
+    StandardAllocator(void* address, size_t size);
+    StandardAllocator(void* address, size_t size, bool enableCache);
 
     ~StandardAllocator() {
         if (mIsInitialized) {
@@ -29,19 +29,19 @@ public:
         }
     }
 
-    void Initialize(void* address, u64 size);
-    void Initialize(void* address, u64 size, bool enableCache);
+    void Initialize(void* address, size_t size);
+    void Initialize(void* address, size_t size, bool enableCache);
     void Finalize();
-    void* Reallocate(void* address, u64 newSize);
-    void* Allocate(u64 size);
-    void* Allocate(u64 size, u64 alignment);
+    void* Reallocate(void* address, size_t newSize);
+    void* Allocate(size_t size);
+    void* Allocate(size_t size, size_t alignment);
     void Free(void* address);
 
-    u64 GetSizeOf(const void* address) const;
+    size_t GetSizeOf(const void* address) const;
     void ClearThreadCache() const;
     void CleanUpManagementArea() const;
-    u64 GetTotalFreeSize() const;
-    u64 GetAllocatableSize() const;
+    size_t GetTotalFreeSize() const;
+    size_t GetAllocatableSize() const;
     void Dump() const;
 
     bool mIsInitialized;

--- a/include/nn/mem.h
+++ b/include/nn/mem.h
@@ -7,24 +7,51 @@
 
 #include <nn/os.h>
 #include <nn/types.h>
+#include <nn/util/util_TypedStorage.h>
 
 namespace nn {
+namespace nlibsdk {
+namespace heap {
+class CentralHeap;
+}  // namespace heap
+}  // namespace nlibsdk
+
 namespace mem {
 class StandardAllocator {
 public:
     StandardAllocator();
+    StandardAllocator(void*, u64);
+    StandardAllocator(void*, u64, bool);
+
+    ~StandardAllocator() {
+        if (mIsInitialized) {
+            Finalize();
+        }
+    }
 
     void Initialize(void* address, u64 size);
+    void Initialize(void* address, u64 size, bool enableCache);
     void Finalize();
     void* Reallocate(void* address, u64 newSize);
     void* Allocate(u64 size);
+    void* Allocate(u64 size, u64 alignment);
     void Free(void* address);
-    void Dump();
 
-    bool mIsInitialized;         // _0
-    bool mIsEnabledThreadCache;  // _1
-    u16 _2;
-    u64* mAllocAddr;  // _4
+    u64 GetSizeOf(const void* address) const;
+    void ClearThreadCache() const;
+    void CleanUpManagementArea() const;
+    u64 GetTotalFreeSize() const;
+    u64 GetAllocatableSize() const;
+    void Dump() const;
+
+    bool mIsInitialized;
+    bool mIsEnabledThreadCache;
+    uintptr_t mAllocAddr;
+    nn::os::TlsSlot mTlsSlot;
+    nn::util::TypedStorage<nn::nlibsdk::heap::CentralHeap, 48, 8> mCentralHeapStorage;
 };
+
+static_assert(sizeof(StandardAllocator) == 0x48);
+
 }  // namespace mem
 }  // namespace nn


### PR DESCRIPTION
This PR completes the `nn::mem::StandardAllocator` class definition so that it is the correct size, and adds additional function declarations from the class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/23)
<!-- Reviewable:end -->
