### PR TITLE
Properly declare nn::os::SystemEvent

### DIFF
--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -67,7 +67,6 @@ struct SemaphoreType {
     std::aligned_storage_t<0x28, 8> storage;
 };
 
-struct SystemEvent;
 struct SystemEventType {
     enum State {
         State_NotInitialized = 0,
@@ -80,6 +79,9 @@ struct SystemEventType {
         nn::os::detail::InterProcessEventType interProcessEvent;
     };
     u8 state;
+};
+struct SystemEvent {
+    SystemEventType m_SystemEventType;
 };
 
 // ARG


### PR DESCRIPTION
Fix nn::os::SystemEvent to have its inner type declared as a field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/26)
<!-- Reviewable:end -->
