### PR TITLE
nn: Add `oe::FocusHandlingMode` and `am::AppletMessage` enums

### DIFF
--- a/include/nn/am.h
+++ b/include/nn/am.h
@@ -1,0 +1,62 @@
+#pragma once
+
+namespace nn::am {
+// based on https://switchbrew.org/wiki/Applet_Manager_services#AppletMessage
+enum AppletMessage {
+    AppletMessage_None,
+    AppletMessage_ChangeIntoForeground,
+    AppletMessage_ChangeIntoBackground,
+    AppletMessage_ExitRequested = 4,
+    AppletMessage_ApplicationExited = 6,
+    AppletMessage_7,
+    AppletMessage_FocusStateChanged = 15,
+    AppletMessage_Resume,
+    AppletMessage_DetectShortPressingHomeButton = 20,
+    AppletMessage_DetectLongPressingHomeButton,
+    AppletMessage_DetectShortPressingPowerButton,
+    AppletMessage_DetectMiddlePressingPowerButton,
+    AppletMessage_DetectLongPressingPowerButton,
+    AppletMessage_RequestToPrepareSleep,
+    AppletMessage_FinishedSleepSequence,
+    AppletMessage_SleepRequiredByHighTemperature,
+    AppletMessage_SleepRequiredByLowBattery,
+    AppletMessage_AutoPowerDown,
+    AppletMessage_OperationModeChanged,
+    AppletMessage_PerformanceModeChanged,
+    AppletMessage_DetectReceivingCecSystemStandby,
+    AppletMessage_SdCardRemoved,
+    AppletMessage_34,
+    AppletMessage_LaunchApplicationRequested = 50,
+    AppletMessage_RequestToDisplay,
+    AppletMessage_ShowApplicationLogo = 55,
+    AppletMessage_HideApplicationLogo,
+    AppletMessage_ForceHideApplicationLogo,
+    AppletMessage_58,
+    AppletMessage_59,
+    AppletMessage_FloatingApplicationDetected,
+    // 7.0.0+
+    AppletMessage_PerformanceConfigurationChanged,
+    AppletMessage_70 = 70,
+    AppletMessage_71,
+    AppletMessage_72,
+    AppletMessage_73,
+    AppletMessage_75 = 75,
+    AppletMessage_80 = 80,
+    AppletMessage_81,
+    AppletMessage_82,
+    AppletMessage_83,
+    AppletMessage_85 = 85,
+    AppletMessage_86,
+    AppletMessage_DetectShortPressingCaptureButton = 90,
+    AppletMessage_AlbumScreenShotTaken = 92,
+    AppletMessage_AlbumRecordingSaved,
+    AppletMessage_94,
+    AppletMessage_100 = 100,
+    AppletMessage_101,
+    // 14.0.0+
+    AppletMessage_DetectShortPressingCaptureButtonForApplet = 110,
+    // 14.0.0+
+    AppletMessage_DetectLongPressingCaptureButtonForApplet,
+    AppletMessage_1000 = 1000
+};
+}  // namespace nn::am

--- a/include/nn/oe.h
+++ b/include/nn/oe.h
@@ -21,7 +21,12 @@ enum PerformanceMode {
     PerformanceMode_Invalid = -1,
 };
 
-typedef s32 FocusHandlingMode;
+enum FocusHandlingMode {
+    FocusHandlingMode_SuspendHomeSleep,
+    FocusHandlingMode_NoSuspend,
+    FocusHandlingMode_SuspendHomeSleepNotify,
+    FocusHandlingMode_AlwaysSuspend
+};
 
 struct DisplayVersion {
     char name[16];


### PR DESCRIPTION
These are required for a recent pull request to the SMO repo, https://github.com/MonsterDruide1/OdysseyDecomp/pull/33.

As the class that is being added here deals with interfacing the system messages sent to the application, the code has to deal with/understand the enums within `nn`, some of which are not added yet. This PR adds the missing ones required by the PR linked above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/29)
<!-- Reviewable:end -->
