### PR TITLE
nn: Add fs.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(NintendoSDK OBJECT
   include/nvn/nvn_FuncPtrInline.h
   include/nvn/nvn.h
   include/nn/types.h
+  include/nn/fs.h
   include/nn/os.h
   include/nn/nifm.h
   include/nn/prepo.h

--- a/include/nn/fs.h
+++ b/include/nn/fs.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <nn/fs/fs_bcat.h>
+#include <nn/fs/fs_directories.h>
+#include <nn/fs/fs_files.h>
+#include <nn/fs/fs_mount.h>
+#include <nn/fs/fs_rom.h>
+#include <nn/fs/fs_save.h>
+#include <nn/fs/fs_types.h>


### PR DESCRIPTION
As #27 removed the main `fs.h` file, this introduced an incompatibility with other usages of `nnheaders`, for example mods. To minimize the impact on these usages, I would want to introduce the `fs.h` file again, which now doesn't hold any contents itself, but just provides an easy way to import all existing structures (including all `fs/*.h` files).

There is still some incompatibility left from the changes done in #27, for example renamed member variables, but ... those were intentional and meant to improve the consistency across the code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/30)
<!-- Reviewable:end -->
