### PR TITLE
fix GetSharedFontLoadState return type and add RequestSharedFontLoad

### DIFF
--- a/include/nn/pl.h
+++ b/include/nn/pl.h
@@ -15,8 +15,9 @@ enum SharedFontType {
 
 enum LoadState { LOADING, LOADED };
 
-bool GetSharedFontLoadState(SharedFontType);
+LoadState GetSharedFontLoadState(SharedFontType);
 void* GetSharedFontAddress(SharedFontType);
 u32 GetSharedFontSize(SharedFontType);
+void RequestSharedFontLoad(SharedFontType);
 
 }  // namespace nn::pl


### PR DESCRIPTION
Couldn't get https://github.com/zeldaret/botw/pull/130 to match when GetSharedFontLoadState returns bool

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/33)
<!-- Reviewable:end -->
