### PR TITLE
Fix syntax error in nn/socket.h

### DIFF
--- a/include/nn/socket.h
+++ b/include/nn/socket.h
@@ -15,7 +15,7 @@ struct ResourceStatistics;
 #if NN_SDK_VER >= NN_MAKE_VER(7, 0, 0)
 struct InAddr {
     u32 addr;
-}
+};
 #endif
 
 // taken from https://switchbrew.org/wiki/Sockets_services#BsdBufferConfig


### PR DESCRIPTION
Fixed missing `;`, and replacing including system headers with forward declare so downstream projects can chose what they want to do
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/34)
<!-- Reviewable:end -->
