### PR TITLE
util/BitFlagSet: fix incorrect member variable name

### DIFF
--- a/include/nn/util/util_BitFlagSet.h
+++ b/include/nn/util/util_BitFlagSet.h
@@ -212,7 +212,7 @@ struct BitFlagSet {
 
         static constexpr BitFlagSet buildMask() {
             BitFlagSet tmp;
-            tmp.data[StorageIndex] = StorageMask;
+            tmp._storage[StorageIndex] = StorageMask;
             return tmp;
         }
 


### PR DESCRIPTION
unclear why this particular instance of `BitFlagSet`'s member variable had the wrong name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/35)
<!-- Reviewable:end -->
