### PR TITLE
nfp: Include types header

### DIFF
--- a/include/nn/nfp/nfp_types.h
+++ b/include/nn/nfp/nfp_types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nn/types.h>
+
 namespace nn::nfp {
 
 using DeviceHandle = u64;


### PR DESCRIPTION
Yet another compiler error. I don't know how it was able to pass the check and I was able to produce actual valid code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/38)
<!-- Reviewable:end -->
