### PR TITLE
album: album::ImageOrientation added and oe

### DIFF
--- a/include/nn/album/album_types.h
+++ b/include/nn/album/album_types.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace nn::album {
+enum ImageOrientation {
+    ImageOrientation_None,
+    ImageOrientation_Rotate90,
+    ImageOrientation_Rotate180,
+    ImageOrientation_Rotate270
+};
+}  // namespace nn::album

--- a/include/nn/oe.h
+++ b/include/nn/oe.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <nn/album/album_types.h>
 #include <nn/settings.h>
 #include <nn/types.h>
 
@@ -28,26 +29,37 @@ enum FocusHandlingMode {
     FocusHandlingMode_AlwaysSuspend
 };
 
+enum FocusState {
+    FocusState_InFocus = 1,
+    FocusState_OutOfFocus = 2,
+    FocusState_Background = 3,
+};
+
 struct DisplayVersion {
     char name[16];
 };
 
+typedef s32 PerformanceConfiguration;
+
 void Initialize();
-void SetPerformanceConfiguration(nn::oe::PerformanceMode, s32);
-OperationMode GetOperationMode();
-PerformanceMode GetPerformanceMode();
+void FinishStartupLogo();
+void EnableGamePlayRecording(void*, u64);
+void SetExpectedVolumeBalance(f32, f32);
+void SetPerformanceConfiguration(nn::oe::PerformanceMode, nn::oe::PerformanceConfiguration);
 void SetResumeNotificationEnabled(bool);
 void SetOperationModeChangedNotificationEnabled(bool);
 void SetPerformanceModeChangedNotificationEnabled(bool);
 void SetFocusHandlingMode(nn::oe::FocusHandlingMode);
-bool TryPopNotificationMessage(u32*);
-s32 GetCurrentFocusState();
-void EnableGamePlayRecording(void*, u64);
-bool IsUserInactivityDetectionTimeExtended();
+void setScreenShotImageOrientation(nn::album::ImageOrientation);
 void SetUserInactivityDetectionTimeExtended(bool);
-void FinishStartupLogo();
-nn::settings::LanguageCode GetDesiredLanguage();
-void GetDisplayVersion(DisplayVersion*);
+bool IsUserInactivityDetectionTimeExtended();
+bool TryPopNotificationMessage(u32*);
 bool TryPopLaunchParameter(size_t*, void*, size_t);
+void GetExpectedVolumeBalance(f32*, f32*);
+void GetDisplayVersion(DisplayVersion*);
+FocusState GetCurrentFocusState();
+OperationMode GetOperationMode();
+PerformanceMode GetPerformanceMode();
+nn::settings::LanguageCode GetDesiredLanguage();
 
 }  // namespace nn::oe


### PR DESCRIPTION
I need it for smo... reasearching it led me to nn::album::ImageOrientation, and smo also has a string that proves its existence. I know the service is caps, but the headers providing it for the game is album.

SMO:
.rodata:00000000016C7138	00000046	C	_ZN2nn2oe29SetScreenShotImageOrientationENS_5album16ImageOrientationE
aka:
nn::oe::SetScreenShotImageOrientation(nn::album::ImageOrientation)

I also added some oe stuff and fixes, like enum FocusState, which I could get from here:
https://switchbrew.org/w/index.php?title=Applet_Manager_services

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/39)
<!-- Reviewable:end -->
