### PR TITLE
nfp: Split ModelInfo and add nfp error codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ add_library(NintendoSDK OBJECT
   include/vapours/results/fatal_results.hpp
   include/vapours/results/sm_results.hpp
   include/vapours/results/psc_results.hpp
+  include/vapours/results/nfp_results.hpp
   include/nv.h
 
   src/NintendoSDK/nvn/nvn_CppFuncPtrImpl.h

--- a/include/nn/nfp/nfp_types.h
+++ b/include/nn/nfp/nfp_types.h
@@ -82,7 +82,8 @@ struct CommonInfo {
 };
 
 struct ModelInfo {
-    u16 characterId;
+    u8 gameId;
+    u8 characterId;
     u8 characterVariant;
     u8 amiiboType;
     u16 modelNumber;

--- a/include/vapours/results.hpp
+++ b/include/vapours/results.hpp
@@ -35,6 +35,7 @@
 #include <vapours/results/loader_results.hpp>
 #include <vapours/results/lr_results.hpp>
 #include <vapours/results/ncm_results.hpp>
+#include <vapours/results/nfp_results.hpp>
 #include <vapours/results/nim_results.hpp>
 #include <vapours/results/ns_results.hpp>
 #include <vapours/results/os_results.hpp>

--- a/include/vapours/results/nfp_results.hpp
+++ b/include/vapours/results/nfp_results.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018-2020 Atmosphère-NX
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <vapours/results/results_common.hpp>
+
+namespace ams::nfp {
+
+    R_DEFINE_NAMESPACE_RESULT_MODULE(115);
+
+    R_DEFINE_ERROR_RESULT(DeviceNotFound,                  64);
+    R_DEFINE_ERROR_RESULT(InvalidArgument,                 65);
+    R_DEFINE_ERROR_RESULT(WrongApplicationAreaSize,        68);
+    R_DEFINE_ERROR_RESULT(WrongDeviceState,                73);
+    R_DEFINE_ERROR_RESULT(NfcDisabled,                     80);
+    R_DEFINE_ERROR_RESULT(WriteAmiiboFailed,               88);
+    R_DEFINE_ERROR_RESULT(TagRemoved,                      97);
+
+    R_DEFINE_ERROR_RESULT(RegistrationIsNotInitialized,    120);
+    R_DEFINE_ERROR_RESULT(ApplicationAreaIsNotInitialized, 128);
+    R_DEFINE_ERROR_RESULT(CorruptedDataWithBackup,         136);
+    R_DEFINE_ERROR_RESULT(CorruptedData,                   144);
+
+    R_DEFINE_ERROR_RESULT(WrongApplicationAreaId,          152);
+    R_DEFINE_ERROR_RESULT(ApplicationAreaExist,            168);
+    R_DEFINE_ERROR_RESULT(NotAnAmiibo,                     178);
+    R_DEFINE_ERROR_RESULT(UnableToAccessBackupFile,        200);
+
+}


### PR DESCRIPTION
After some discussions and implementations we determined that is better to split this value into two despite some games using an u16.

SMO also makes use of some nfp error codes. So it will be nice to have all of them defined as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/40)
<!-- Reviewable:end -->
