### PR TITLE
g3d/ModelObj: Add `GetNumShapes()`

### DIFF
--- a/include/nn/g3d/ModelObj.h
+++ b/include/nn/g3d/ModelObj.h
@@ -14,6 +14,8 @@ class ModelObj {
 public:
     SkeletonObj* GetSkeleton() const { return m_Skeleton; }
 
+    s32 GetNumShapes() const { return m_NumShapes; }
+
 private:
     struct InitializeArgument;
 


### PR DESCRIPTION
Required for implementing some actor creation functions in SMO, which check whether this value is `>= 1` to avoid creating objects for managing the rendering if there is nothing to render.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/41)
<!-- Reviewable:end -->
