### PR TITLE
g3d/ModelObj: Add getter for `_8c`

### DIFF
--- a/include/nn/g3d/ModelObj.h
+++ b/include/nn/g3d/ModelObj.h
@@ -16,6 +16,8 @@ public:
 
     s32 GetNumShapes() const { return m_NumShapes; }
 
+    s32 get_8c() const { return _8c; }
+
 private:
     struct InitializeArgument;
 


### PR DESCRIPTION
Required for SMO's `ActorInitFunction`, which fetches this offset to determine which core should be used to process this model (`ビュー更新(コア1/2)`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/45)
<!-- Reviewable:end -->
