### PR TITLE
nnSdk: Remove implementation of `nn::util::ReferSymbol`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,6 @@ add_library(NintendoSDK OBJECT
   src/NintendoSDK/nvn/nvn_CppFuncPtrImpl.h
   src/NintendoSDK/nvn/nvn_FuncPtrImpl.h
   src/NintendoSDK/nvn/nvn_Impl.cpp
-  src/NintendoSDK/nnSdk/util.cpp
 )
 
 target_include_directories(NintendoSDK PUBLIC include/)

--- a/src/NintendoSDK/nnSdk/util.cpp
+++ b/src/NintendoSDK/nnSdk/util.cpp
@@ -1,7 +1,0 @@
-#include <nn/util.h>
-
-namespace nn::util {
-
-void ReferSymbol(const void*) {}
-
-}  // namespace nn::util


### PR DESCRIPTION
After speaking to @ThePixelGamer, it seems like this folder was only a placeholder - the function contained here, `nn::util::ReferSymbol`, is part of the SDK and should not be generated in games using this repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/46)
<!-- Reviewable:end -->
