### PR TITLE
Add `nn::diag::detail::OnAssertionFailure`

### DIFF
--- a/include/nn/diag.h
+++ b/include/nn/diag.h
@@ -17,11 +17,15 @@ struct ModuleInfo {
     u64 mSize;
 };
 
+enum AssertionType {};
+
 namespace detail {
 // LOG
 void LogImpl(nn::diag::LogMetaData const&, char const*, ...);
 void AbortImpl(char const*, char const*, char const*, s32);
 void AbortImpl(char const*, char const*, char const*, int, Result);
+
+void OnAssertionFailure(nn::diag::AssertionType, char const*, char const*, char const*, int);
 }  // namespace detail
 
 // MODULE / SYMBOL


### PR DESCRIPTION
Quick PR to add a function used [here](https://github.com/GRAnimated/MinecraftLCE/blob/2a512fe8b30461b0b8798d4d5cc6f2eb1f8148ee/src/Minecraft.Client/renderer/Renderer.cpp#L82). I'm not interested in filling out the enum (unless somebody has the values that should go in there) or improving the rest of the header, I just need this in ASAP so I can move my decomp off this branch and back onto upstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/47)
<!-- Reviewable:end -->
