### PR TITLE
Convert Tick from typedef to struct

### DIFF
--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -39,7 +39,9 @@ struct InterProcessEventType {
 };
 }  // namespace detail
 
-typedef u64 Tick;
+struct Tick {
+    u64 value;
+};
 
 struct LightEventType {
     std::aligned_storage_t<0xc, 4> storage;


### PR DESCRIPTION
This should make it match the symbol `nn::os::ConvertToTimeSpan(nn::os::Tick)` from the SDK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/48)
<!-- Reviewable:end -->
