### PR TITLE
os: Add `Tick::Tick(u64)`

### DIFF
--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -40,6 +40,8 @@ struct InterProcessEventType {
 }  // namespace detail
 
 struct Tick {
+    Tick(u64 val) : value(val) {}
+
     u64 value;
 };
 


### PR DESCRIPTION
As discussed in https://github.com/open-ead/sead/pull/211, we want to add this constructor to simplify some of the changes required in `sead` due to making `Tick` *not* a `typedef`.