### PR TITLE
util: Fix iterators of `BitArray` and `IntrusiveList`

### DIFF
--- a/include/nn/util/util_BitArray.h
+++ b/include/nn/util/util_BitArray.h
@@ -37,10 +37,14 @@ public:
     };
 
     class iterator {
+    public:
         typedef difference_type difference_type;
         typedef reference reference;
         typedef pointer pointer;
+        typedef std::random_access_iterator_tag iterator_category;
+        typedef value_type value_type;
 
+    private:
         BitArray* m_pParent;
         difference_type m_Pos;
 
@@ -69,10 +73,14 @@ public:
     };
 
     class const_iterator {
+    public:
         typedef difference_type difference_type;
         typedef const_reference reference;
         typedef const_pointer pointer;
+        typedef std::random_access_iterator_tag iterator_category;
+        typedef value_type value_type;
 
+    private:
         const BitArray* m_pParent;
         difference_type m_Pos;
 

--- a/include/nn/util/util_IntrusiveList.h
+++ b/include/nn/util/util_IntrusiveList.h
@@ -72,6 +72,7 @@ public:
         typedef difference_type difference_type;
         typedef value_type* pointer;
         typedef value_type& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
 
         const_iterator(pointer p) : m_Node(p) {}
 
@@ -92,8 +93,10 @@ public:
     class iterator {
     public:
         typedef value_type value_type;
+        typedef difference_type difference_type;
         typedef value_type* pointer;
         typedef value_type& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
 
         iterator(pointer p) : m_Node(p) {}
 
@@ -197,12 +200,15 @@ public:
     typedef std::reverse_iterator<iterator> reverse_iterator;
     typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
     typedef int size_type;
+    typedef int difference_type;
 
     class const_iterator {
     public:
         typedef T value_type;
+        typedef difference_type difference_type;
         typedef value_type* pointer;
         typedef value_type& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
 
         reference operator*() const;
         pointer operator->() const;
@@ -228,8 +234,10 @@ public:
     class iterator {
     public:
         typedef T value_type;
+        typedef difference_type difference_type;
         typedef value_type* pointer;
         typedef value_type& reference;
+        typedef std::bidirectional_iterator_tag iterator_category;
 
         operator const_iterator() const {
             return static_cast<detail::IntrusiveListImplementation::const_iterator>(m_Iterator);


### PR DESCRIPTION
Currently, a line like this causes cryptic error messages:
`nn::util::BitArray::const_reverse_iterator it = arr.rbegin();`

After two hours of debugging and working with C++ iterators, I found a fix: Declaring more of the elements required to build `iterator_trait`, and changing them to `public` to allow accessing them outside.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/60)
<!-- Reviewable:end -->
