### PR TITLE
swkbd: Add support for multiple FW versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ add_library(NintendoSDK OBJECT
   include/nn/ui2d/Parts.h
   include/nn/ui2d/Types.h
   include/nn/ui2d/Util.h
+  include/nn/swkbd/swkbd.h
   include/nn/g3d/BindFuncTable.h
   include/nn/g3d/ModelObj.h
   include/nn/g3d/ResMaterialAnim.h
@@ -311,7 +312,7 @@ function(nn_ver ID)
   list(POP_FRONT VER MAJOR MINOR PATCH)
   
   foreach(VAR IN ITEMS MAJOR MINOR PATCH)
-    target_compile_definitions(NintendoSDK PRIVATE ${ID}_${VAR}=${${VAR}})
+    target_compile_definitions(NintendoSDK PUBLIC ${ID}_${VAR}=${${VAR}})
   endforeach()
 endfunction()
 

--- a/include/nn/applet.h
+++ b/include/nn/applet.h
@@ -2,4 +2,5 @@
 
 namespace nn::applet {
 enum class ExitReason { Normal = 0, Canceled = 1, Abnormal = 2, Unexpected = 10 };
-}
+typedef int LibraryAppletHandle;
+}  // namespace nn::applet

--- a/include/nn/applet.h
+++ b/include/nn/applet.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <nn/types.h>
+
 namespace nn::applet {
 enum class ExitReason { Normal = 0, Canceled = 1, Abnormal = 2, Unexpected = 10 };
-typedef int LibraryAppletHandle;
+
+// TODO: Fill members of LibraryAppletHandle. This contains a service ctx
+struct LibraryAppletHandle;
 }  // namespace nn::applet

--- a/include/nn/applet.h
+++ b/include/nn/applet.h
@@ -5,9 +5,10 @@
 namespace nn::applet {
 enum class ExitReason { Normal = 0, Canceled = 1, Abnormal = 2, Unexpected = 10 };
 
+// https://switchbrew.org/wiki/Applet_Manager_services#AppletId
 enum class AppletId {
     None = 0x00,
-    application = 0x01,
+    Application = 0x01,
     OverlayApplet = 0x02,
     SystemAppletMenu = 0x03,
     SystemApplication = 0x04,
@@ -28,13 +29,18 @@ enum class AppletId {
     LibraryAppletLoginShare = 0x18,
     LibraryAppletWifiWebAuth = 0x19,
     LibraryAppletMyPage = 0x1A,
+    LibraryAppletGift = 0x1B,
+    LibraryAppletUserMigration = 0x1C,
+    // NOTE: more entries exist in later versions
+
 };
 
-enum class AppletMode {
+// https://switchbrew.org/wiki/Applet_Manager_services#LibraryAppletMode
+enum class LibraryAppletMode {
     AllForeground = 0,
-    Background = 1,
+    PartialForeground = 1,
     NoUi = 2,
-    BackgroundIndirect = 3,
+    PartialForegroundWithIndirectDisplay = 3,
     AllForegroundInitiallyHidden = 4,
 };
 

--- a/include/nn/applet.h
+++ b/include/nn/applet.h
@@ -5,6 +5,45 @@
 namespace nn::applet {
 enum class ExitReason { Normal = 0, Canceled = 1, Abnormal = 2, Unexpected = 10 };
 
-// TODO: Fill members of LibraryAppletHandle. This contains a service ctx
-struct LibraryAppletHandle;
+enum class AppletId {
+    None = 0x00,
+    application = 0x01,
+    OverlayApplet = 0x02,
+    SystemAppletMenu = 0x03,
+    SystemApplication = 0x04,
+    LibraryAppletAuth = 0x0A,
+    LibraryAppletCabinet = 0x0B,
+    LibraryAppletController = 0x0C,
+    LibraryAppletDataErase = 0x0D,
+    LibraryAppletError = 0x0E,
+    LibraryAppletNetConnect = 0x0F,
+    LibraryAppletPlayerSelect = 0x10,
+    LibraryAppletSwkbd = 0x11,
+    LibraryAppletMiiEdit = 0x12,
+    LibraryAppletWeb = 0x13,
+    LibraryAppletShop = 0x14,
+    LibraryAppletPhotoViewer = 0x15,
+    LibraryAppletSet = 0x16,
+    LibraryAppletOfflineWeb = 0x17,
+    LibraryAppletLoginShare = 0x18,
+    LibraryAppletWifiWebAuth = 0x19,
+    LibraryAppletMyPage = 0x1A,
+};
+
+enum class AppletMode {
+    AllForeground = 0,
+    Background = 1,
+    NoUi = 2,
+    BackgroundIndirect = 3,
+    AllForegroundInitiallyHidden = 4,
+};
+
+struct LibraryAppletHandle {
+    char _filler0[0x18];
+    AppletId id;
+    AppletMode mode;
+    char _filler20[0x78];
+};
+static_assert(sizeof(LibraryAppletHandle) == 0x98);
+
 }  // namespace nn::applet

--- a/include/nn/swkbd/swkbd.h
+++ b/include/nn/swkbd/swkbd.h
@@ -92,6 +92,8 @@ enum class DictionaryLang {
 
 enum class CloseResult { Enter, Cancel };
 
+enum class Trigger : u8 { Default };
+
 struct DictionaryInfo {
     u32 offset;
     u16 size;
@@ -116,13 +118,27 @@ struct KeyboardConfig {
     bool isUseNewLine;
     bool isUseUtf8;
     bool isUseBlurBackground;
-    int _initialStringOffset;
-    int _initialStringLength;
-    int _userDictionaryOffset;
-    int _userDictionaryNum;
-    bool _isUseTextCheck;
-    void* _textCheckCallback;
+    int initialStringOffset;
+    int initialStringLength;
+    int userDictionaryOffset;
+    int userDictionaryNum;
+    bool isUseTextCheck;
+    void* textCheckCallback;
+
+#if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
     int separateTextPos[0x8];
+#endif
+
+#if NN_SDK_VER >= NN_MAKE_VER(6, 0, 0)
+    u64 customDictionaryEntries[0x18];
+    u8 customDictionaryNum;
+#endif
+
+#if NN_SDK_VER >= NN_MAKE_VER(8, 0, 0)
+    u8 _3c1;
+    u8 filler[0xd];
+    u8 trigger;
+#endif
 };
 
 struct ShowKeyboardArg {
@@ -157,14 +173,63 @@ private:
     int bufsize;
 };
 
-struct UserWord;  // TODO contents missing
+struct UserWord;   // TODO contents missing
+struct KbdConfig;  // TODO contents missing
+
+struct CustomizedDictionarySet {
+    void* buffer;    // 0x1000-byte aligned buffer.
+    int bufferSize;  // 0x1000-byte aligned buffer size.
+    u64 entries[0x18];
+    u16 totalEntries;
+};
+
+typedef TextCheckResult (*TextCheckCb)(void*, ulong*, String*);
+
+int ConvertUtf8ToUtf16(void*, int, const char*, int);
+int ConvertUtf8ToUtf16(void*, int, const char*);
+int GetLengthOfConvertedStringUtf8ToUtf16(const char*);
+void MakePresetDefault(KeyboardConfig*);
+void MakePresetPassword(KeyboardConfig*);
+void MakePresetUsername(KeyboardConfig*);
+void MakePresetDownloadCode(KeyboardConfig*);
+Result GetInteractiveOutStorageCallback(nn::applet::LibraryAppletHandle, String*,
+                                        const ShowKeyboardArg&);
+ulong GetRequiredTextCheckWorkBufferSize();
+void ReadCloseResultAndString(nn::applet::LibraryAppletHandle, CloseResult*, String*);
+void CopyInitialStringInfo(ShowKeyboardArg*, int);
+void CopyUserDictionaryInfo(ShowKeyboardArg*, int);
+
+#if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
+ulong GetRequiredWorkBufferSize(int);
+#endif
+
+#if NN_SDK_VER >= NN_MAKE_VER(6, 0, 0)
+void keyboardConfig2kbdConfig(const KeyboardConfig&, KbdConfig*);
+#endif
+
+Result ShowKeyboard(String*, const ShowKeyboardArg&);
+
+#if NN_SDK_VER >= NN_MAKE_VER(8, 0, 0)
+Result ShowKeyboard(String*, const ShowKeyboardArg&, Trigger);
+#endif
+
+void InitializeKeyboardConfig(KeyboardConfig*);
+void MakePreset(KeyboardConfig*, Preset);
 
 ulong GetRequiredWorkBufferSize(bool);
+
+#if NN_SDK_VER >= NN_MAKE_VER(1, 0, 0) && NN_SDK_VER < NN_MAKE_VER(2, 0, 0)
+ulong GetRequiredWorkBufferSize(int);
+#endif
+
+#if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
+ulong GetRequiredWorkBufferSize();
+#endif
+
+#if NN_SDK_VER < NN_MAKE_VER(2, 0, 0)
 ulong GetRequiredStringBufferSize();
-nn::applet::ExitReason GetExitReason();
-void MakePreset(KeyboardConfig*, Preset);
-void SetHeaderText(KeyboardConfig*, const char16_t*);
-void SetSubText(KeyboardConfig*, const char16_t*);
+#endif
+
 void SetOkText(KeyboardConfig*, const char16_t*);
 void SetOkTextUtf8(KeyboardConfig*, const char*);
 void SetLeftOptionalSymbolKey(KeyboardConfig*, char16_t);
@@ -180,7 +245,16 @@ void SetGuideTextUtf8(KeyboardConfig*, const char*);
 void SetInitialText(ShowKeyboardArg*, const char16_t*);
 void SetInitialTextUtf8(ShowKeyboardArg*, const char*);
 void SetUserWordList(ShowKeyboardArg*, const UserWord*, int);
-int ShowKeyboard(String*, const ShowKeyboardArg&);
+
+#if NN_SDK_VER >= NN_MAKE_VER(6, 0, 0)
+void SetCustomizedDictionaries(ShowKeyboardArg*, const CustomizedDictionarySet&);
+#endif
+
+void SetTextCheckCallback(ShowKeyboardArg*, TextCheckCb);
+
+#if NN_SDK_VER < NN_MAKE_VER(4, 0, 0)
+nn::applet::ExitReason GetExitReason();
+#endif
 
 extern nn::applet::ExitReason g_ExitReason;
 }  // namespace nn::swkbd

--- a/include/nn/swkbd/swkbd.h
+++ b/include/nn/swkbd/swkbd.h
@@ -111,22 +111,22 @@ struct KeyboardConfig {
     char headerText[0x82];
     char subText[0x102];
     char guideText[0x202];
-    int textMaxLength;
-    int textMinLength;
+    s32 textMaxLength;
+    s32 textMinLength;
     PasswordMode passwordMode;
     InputFormMode inputFormMode;
     bool isUseNewLine;
     bool isUseUtf8;
     bool isUseBlurBackground;
-    int initialStringOffset;
-    int initialStringLength;
-    int userDictionaryOffset;
-    int userDictionaryNum;
+    s32 initialStringOffset;
+    s32 initialStringLength;
+    s32 userDictionaryOffset;
+    s32 userDictionaryNum;
     bool isUseTextCheck;
     void* textCheckCallback;
 
 #if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
-    int separateTextPos[0x8];
+    s32 separateTextPos[0x8];
 #endif
 
 #if NN_SDK_VER >= NN_MAKE_VER(6, 0, 0)
@@ -137,7 +137,7 @@ struct KeyboardConfig {
 #if NN_SDK_VER >= NN_MAKE_VER(8, 0, 0)
     u8 _3c1;
     u8 filler[0xd];
-    u8 trigger;
+    Trigger trigger;
 #endif
 };
 
@@ -153,11 +153,11 @@ struct ShowKeyboardArg {
 
 class String {
 public:
-    String(int size) {
+    String(s32 size) {
         bufsize = size;
         strBuf = nullptr;
     }
-    String(int size, char* buf) {
+    String(s32 size, char* buf) {
         bufsize = size;
         strBuf = buf;
     }
@@ -170,7 +170,7 @@ public:
 
 private:
     char* strBuf;
-    int bufsize;
+    s32 bufsize;
 };
 
 struct UserWord;   // TODO contents missing
@@ -178,30 +178,30 @@ struct KbdConfig;  // TODO contents missing
 
 struct CustomizedDictionarySet {
     void* buffer;    // 0x1000-byte aligned buffer.
-    int bufferSize;  // 0x1000-byte aligned buffer size.
+    s32 bufferSize;  // 0x1000-byte aligned buffer size.
     u64 entries[0x18];
     u16 totalEntries;
 };
 
-typedef TextCheckResult (*TextCheckCb)(void*, ulong*, String*);
+#if NN_SDK_VER >= NN_MAKE_VER(8, 0, 0)
+using TextCheckCb = TextCheckResult (*)(void*, u32*, String*);
+#else
+using TextCheckCb = TextCheckResult (*)(void*, u64*, String*);
+#endif
 
-int ConvertUtf8ToUtf16(void*, int, const char*, int);
-int ConvertUtf8ToUtf16(void*, int, const char*);
-int GetLengthOfConvertedStringUtf8ToUtf16(const char*);
+s32 ConvertUtf8ToUtf16(void*, s32, const char*, s32);
+s32 ConvertUtf8ToUtf16(void*, s32, const char*);
+s32 GetLengthOfConvertedStringUtf8ToUtf16(const char*);
 void MakePresetDefault(KeyboardConfig*);
 void MakePresetPassword(KeyboardConfig*);
 void MakePresetUsername(KeyboardConfig*);
 void MakePresetDownloadCode(KeyboardConfig*);
 Result GetInteractiveOutStorageCallback(nn::applet::LibraryAppletHandle, String*,
                                         const ShowKeyboardArg&);
-ulong GetRequiredTextCheckWorkBufferSize();
+size_t GetRequiredTextCheckWorkBufferSize();
 void ReadCloseResultAndString(nn::applet::LibraryAppletHandle, CloseResult*, String*);
-void CopyInitialStringInfo(ShowKeyboardArg*, int);
-void CopyUserDictionaryInfo(ShowKeyboardArg*, int);
-
-#if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
-ulong GetRequiredWorkBufferSize(int);
-#endif
+void CopyInitialStringInfo(ShowKeyboardArg*, s32);
+void CopyUserDictionaryInfo(ShowKeyboardArg*, s32);
 
 #if NN_SDK_VER >= NN_MAKE_VER(6, 0, 0)
 void keyboardConfig2kbdConfig(const KeyboardConfig&, KbdConfig*);
@@ -216,20 +216,13 @@ Result ShowKeyboard(String*, const ShowKeyboardArg&, Trigger);
 void InitializeKeyboardConfig(KeyboardConfig*);
 void MakePreset(KeyboardConfig*, Preset);
 
-ulong GetRequiredWorkBufferSize(bool);
+size_t GetRequiredWorkBufferSize(bool);
 
-#if NN_SDK_VER >= NN_MAKE_VER(1, 0, 0) && NN_SDK_VER < NN_MAKE_VER(2, 0, 0)
-ulong GetRequiredWorkBufferSize(int);
+#if NN_SDK_VER >= NN_MAKE_VER(1, 0, 0)
+size_t GetRequiredWorkBufferSize(s32);
 #endif
 
-#if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
-ulong GetRequiredWorkBufferSize();
-#endif
-
-#if NN_SDK_VER < NN_MAKE_VER(2, 0, 0)
-ulong GetRequiredStringBufferSize();
-#endif
-
+size_t GetRequiredStringBufferSize();
 void SetOkText(KeyboardConfig*, const char16_t*);
 void SetOkTextUtf8(KeyboardConfig*, const char*);
 void SetLeftOptionalSymbolKey(KeyboardConfig*, char16_t);
@@ -244,7 +237,7 @@ void SetGuideText(KeyboardConfig*, const char16_t*);
 void SetGuideTextUtf8(KeyboardConfig*, const char*);
 void SetInitialText(ShowKeyboardArg*, const char16_t*);
 void SetInitialTextUtf8(ShowKeyboardArg*, const char*);
-void SetUserWordList(ShowKeyboardArg*, const UserWord*, int);
+void SetUserWordList(ShowKeyboardArg*, const UserWord*, s32);
 
 #if NN_SDK_VER >= NN_MAKE_VER(6, 0, 0)
 void SetCustomizedDictionaries(ShowKeyboardArg*, const CustomizedDictionarySet&);
@@ -253,7 +246,7 @@ void SetCustomizedDictionaries(ShowKeyboardArg*, const CustomizedDictionarySet&)
 void SetTextCheckCallback(ShowKeyboardArg*, TextCheckCb);
 
 #if NN_SDK_VER < NN_MAKE_VER(4, 0, 0)
-nn::applet::ExitReason GetExitReason();
+nn::applet::ExitReason getExitReason();
 #endif
 
 extern nn::applet::ExitReason g_ExitReason;

--- a/include/nn/swkbd/swkbd.h
+++ b/include/nn/swkbd/swkbd.h
@@ -123,7 +123,10 @@ struct KeyboardConfig {
     s32 userDictionaryOffset;
     s32 userDictionaryNum;
     bool isUseTextCheck;
+
+#if NN_SDK_VER < NN_MAKE_VER(6, 0, 0)
     void* textCheckCallback;
+#endif
 
 #if NN_SDK_VER >= NN_MAKE_VER(3, 0, 0)
     s32 separateTextPos[0x8];
@@ -135,9 +138,10 @@ struct KeyboardConfig {
 #endif
 
 #if NN_SDK_VER >= NN_MAKE_VER(8, 0, 0)
-    u8 _3c1;
+    u8 isCancelButtonDisabled;
     u8 filler[0xd];
     Trigger trigger;
+    u8 filler2[0x4];
 #endif
 };
 

--- a/include/nn/swkbd/swkbd.h
+++ b/include/nn/swkbd/swkbd.h
@@ -174,7 +174,7 @@ public:
 
 private:
     char* strBuf;
-    s32 bufsize;
+    size_t bufsize;
 };
 
 struct UserWord;   // TODO contents missing


### PR DESCRIPTION
Add headers for all swkbd revisions from 0x5 up to 0x8000D or firmware 0 to 16.

Apparently there's a new revision in fw 19 but I don't have anything higher than fw 16 to validate against. `NN_SDK_VER` is null if the target definition is set to private for whatever reason on SMO. If anyone has an actual understanding on how that works you are welcome.

closes #50

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/62)
<!-- Reviewable:end -->
