### PR TITLE
all: fix declarations and types for symbols

### DIFF
--- a/include/nn/account.h
+++ b/include/nn/account.h
@@ -10,8 +10,12 @@
 
 namespace nn {
 namespace account {
-typedef char Nickname[0x21];
-typedef u64 NetworkServiceAccountId;
+struct Nickname {
+    char m_Buffer[0x21];
+};
+struct NetworkServiceAccountId {
+    u64 m_Id;
+};
 
 class AsyncContext;
 
@@ -40,6 +44,7 @@ Result LoadNetworkServiceAccountIdTokenCache(u64*, char*, u64, UserHandle const&
 
 Result GetLastOpenedUser(Uid*);
 Result GetNickname(Nickname* nickname, Uid const& userID);
+Result GetNetworkServiceAccountId(NetworkServiceAccountId*, const UserHandle&);
 
 Result GetUserId(Uid* uid, const UserHandle& handle);
 Result OpenPreselectedUser(UserHandle* handle);
@@ -47,6 +52,7 @@ Result OpenPreselectedUser(UserHandle* handle);
 class AsyncContext {
 public:
     AsyncContext();
+    ~AsyncContext();
 
     Result HasDone(bool*);
     Result GetResult();

--- a/include/nn/audio.h
+++ b/include/nn/audio.h
@@ -147,6 +147,7 @@ struct VoiceType {
 };
 
 struct DeviceSinkType {
+    struct DownMixParameter;
     u64* _0;
 };
 

--- a/include/nn/friends.h
+++ b/include/nn/friends.h
@@ -10,7 +10,12 @@
 
 namespace nn {
 namespace friends {
-typedef char Url[0xA0];
+struct Url {
+    char m_Buffer[0xA0];
+};
+struct ImageSize {
+    s32 m_Size;
+};
 
 class AsyncContext;
 class Profile;
@@ -27,7 +32,7 @@ public:
     nn::account::NetworkServiceAccountId GetAccountId() const;
     nn::account::Nickname& GetNickname() const;
     bool IsValid() const;
-    Result GetProfileImageUrl(nn::friends::Url*, s32);
+    Result GetProfileImageUrl(nn::friends::Url*, ImageSize) const;
 };
 
 class AsyncContext {

--- a/include/nn/fs/fs_rom.h
+++ b/include/nn/fs/fs_rom.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nn/nn.h>
 #include <nn/fs/fs_types.h>
 
 namespace nn::fs {

--- a/include/nn/fs/fs_rom.h
+++ b/include/nn/fs/fs_rom.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <nn/nn.h>
 #include <nn/fs/fs_types.h>
+#include <nn/nn.h>
 
 namespace nn::fs {
 

--- a/include/nn/fs/fs_save.h
+++ b/include/nn/fs/fs_save.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <nn/nn.h>
 #include <nn/account.h>
 #include <nn/fs/fs_types.h>
+#include <nn/nn.h>
 
 namespace nn::fs {
 

--- a/include/nn/fs/fs_save.h
+++ b/include/nn/fs/fs_save.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nn/nn.h>
 #include <nn/account.h>
 #include <nn/fs/fs_types.h>
 

--- a/include/nn/fs/fs_save.h
+++ b/include/nn/fs/fs_save.h
@@ -3,10 +3,6 @@
 #include <nn/account.h>
 #include <nn/fs/fs_types.h>
 
-namespace nn {
-typedef u64 ApplicationId;
-};
-
 namespace nn::fs {
 
 Result EnsureSaveData(const nn::account::Uid&);

--- a/include/nn/fs/fs_types.h
+++ b/include/nn/fs/fs_types.h
@@ -2,10 +2,7 @@
 
 #include <nn/types.h>
 
-namespace nn {
-typedef u64 ApplicationId;
-
-namespace fs {
+namespace nn::fs {
 using namespace ams::fs;  // for errors
 
 typedef u64 UserId;
@@ -78,5 +75,4 @@ struct WriteOption {
         return op;
     }
 };
-}  // namespace fs
-}  // namespace nn
+}  // namespace nn::fs

--- a/include/nn/image.h
+++ b/include/nn/image.h
@@ -35,7 +35,7 @@ public:
     nn::image::JpegStatus Analyze();
     nn::image::Dimension GetAnalyzedDimension() const;
     s64 GetAnalyzedWorkBufferSize() const;
-    JpegStatus Decode(void* out, s64, s32 alignment, void*, s64);
+    JpegStatus Decode(void* out, u64, s32 alignment, void*, u64);
 
     nn::image::ProcessStage mProcessStage;  // _8
     void* mData;                            // _C

--- a/include/nn/nfp/nfp.h
+++ b/include/nn/nfp/nfp.h
@@ -8,7 +8,9 @@ struct SystemEventType;
 
 namespace nn::nfp {
 
-using DeviceHandle = u64;
+struct DeviceHandle {
+    u64 m_Id;
+};
 
 enum State : u32;
 enum DeviceState : u32;

--- a/include/nn/nn.h
+++ b/include/nn/nn.h
@@ -11,7 +11,7 @@ namespace nn {
 struct ApplicationId {
     u64 m_Id;
 };
-};
+}  // namespace nn
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/nn/nn.h
+++ b/include/nn/nn.h
@@ -8,7 +8,9 @@
 #include <nn/types.h>
 
 namespace nn {
-typedef u64 ApplicationId;
+struct ApplicationId {
+    u64 m_Id;
+};
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
`typedef` results in the typedef-ed type appearing in the signature, instead of the name of the newly defined "type".
The easiest way to fix that is by creating full structs instead of only aliases, even if they only contain one member then.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/65)
<!-- Reviewable:end -->
