### PR TITLE
nfp: Fix type of `DeviceHandle`

### DIFF
--- a/include/nn/nfp/nfp.h
+++ b/include/nn/nfp/nfp.h
@@ -8,19 +8,16 @@ struct SystemEventType;
 
 namespace nn::nfp {
 
-struct DeviceHandle {
-    u64 m_Id;
-};
-
 enum State : u32;
 enum DeviceState : u32;
 enum ModelType : u32;
 enum MountTarget : u32;
 
-struct TagInfo;
 struct CommonInfo;
+struct DeviceHandle;
 struct ModelInfo;
 struct RegisterInfo;
+struct TagInfo;
 
 Result Initialize();
 Result Finalize();

--- a/include/nn/nfp/nfp_types.h
+++ b/include/nn/nfp/nfp_types.h
@@ -4,7 +4,9 @@
 
 namespace nn::nfp {
 
-using DeviceHandle = u64;
+struct DeviceHandle {
+    u64 m_Id;
+};
 
 const s32 AmiiboNameLength = 10;
 


### PR DESCRIPTION
Fixup for #65.

At the moment, two conflicting types for `nn::nfp::DeviceHandle` exist - one being a `typedef`, one a `struct`.

Changing them both to `struct`s fixes this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/66)
<!-- Reviewable:end -->
