### PR TITLE
fs: Fix reference to `ApplicationId`

### DIFF
--- a/include/nn/fs/fs_types.h
+++ b/include/nn/fs/fs_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nn/nn.h>
 #include <nn/types.h>
 
 namespace nn::fs {


### PR DESCRIPTION
Another fixup for #65.

`fs_bcat.h` tries mentioning `ApplicationId` - previously, this was provided by `fs_types.h` as a `typedef`, but has now been moved into `nn.h` as a `struct`. To fix this, just add another include.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/67)
<!-- Reviewable:end -->
