### PR TITLE
util: Add type for `RelocationTable::Entry`

### DIFF
--- a/include/nn/util/util_BinaryFormat.h
+++ b/include/nn/util/util_BinaryFormat.h
@@ -81,6 +81,13 @@ struct RelocationTable {
         size_t GetSize() const;
     };
 
+    struct Entry {
+        u32 file_offset;
+        u16 num_chunks;
+        u8 relocated_words_per_chunk;
+        u8 non_relocated_words_per_chunk;
+    };
+
     static const int PackedSignature;
     BinBlockSignature _signature;
     uint32_t _position;


### PR DESCRIPTION
There is no trace of this type existing as a type/class in the game's binary or SDK, but it greatly simplifies code around relocations.

Names for the offsets have been taken from https://nintendo-formats.com/libs/switch/binary.html#relocation-entry, and independently verified to be correct by looking into `nn::util::RelocationTable::Relocate(void)` (from the SDK).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/71)
<!-- Reviewable:end -->
