### PR TITLE
nn: replace `main(int, char**)` with `nnMain()`

### DIFF
--- a/include/nn/nn.h
+++ b/include/nn/nn.h
@@ -17,8 +17,8 @@ struct ApplicationId {
 extern "C" {
 #endif
 
-int main(int argc, char** argv);
 void nninitStartup();
+void nnMain();
 
 void _init();
 void _fini();


### PR DESCRIPTION
`main(int, char**)` never existed in the SDK, according to my research and knowledge.

`nninitStartup()` and `nnMain()` are provided by the main game binary and called by RTLD to prepare and launch the game. The newer variant is a single function called `nn::init::Start()`, but I have yet to work on a game that uses this. Anyways, `main(...)` seems wrong and should be removed.

EDIT: Odyssey does use `nn::init::Start()`, so it seems like the special branch for manually calling `nninitStartup()` and `nnMain()` from RTLD is even older than this game. Anyways, doesn't change anything about the intention of this PR.

https://github.com/shadowninja108/oss-rtld/blob/7d18fe6bbf0f3612aafefd71be2e9397d0a93549/source/main.cpp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/72)
<!-- Reviewable:end -->
