### PR TITLE
hid: Add return type to `GetNpadStates`

### DIFF
--- a/include/nn/hid.h
+++ b/include/nn/hid.h
@@ -518,11 +518,11 @@ void GetNpadState(NpadJoyDualState*, const u32& port);
 void GetNpadState(NpadJoyLeftState*, const u32& port);
 void GetNpadState(NpadJoyRightState*, const u32& port);
 
-void GetNpadStates(NpadFullKeyState*, s32, const u32& port);
-void GetNpadStates(NpadHandheldState*, s32, const u32& port);
-void GetNpadStates(NpadJoyDualState*, s32, const u32& port);
-void GetNpadStates(NpadJoyLeftState*, s32, const u32& port);
-void GetNpadStates(NpadJoyRightState*, s32, const u32& port);
+s32 GetNpadStates(NpadFullKeyState*, s32, const u32& port);
+s32 GetNpadStates(NpadHandheldState*, s32, const u32& port);
+s32 GetNpadStates(NpadJoyDualState*, s32, const u32& port);
+s32 GetNpadStates(NpadJoyLeftState*, s32, const u32& port);
+s32 GetNpadStates(NpadJoyRightState*, s32, const u32& port);
 
 void InitializeMouse();
 void InitializeKeyboard();


### PR DESCRIPTION
When checking the SDK binary, it gets obvious that `GetNpadStates` should return an integer. According to my understanding, `GetNpadStates` can fetch multiple states at once (`mSamplingNumber` tells them apart), so the first parameter is a buffer of potentially multiple states, the second parameter is the buffer size and the third is the port. The return type might be the number of entries that were added to the buffer, but I'm not fully sure about that. Odyssey works with hardcoded buffer size of 16, but ignores the return value of this function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/73)
<!-- Reviewable:end -->
