### PR TITLE
util: Add `IntrusiveListBaseNode` and traits

### DIFF
--- a/include/nn/util/util_IntrusiveList.h
+++ b/include/nn/util/util_IntrusiveList.h
@@ -338,6 +338,30 @@ private:
     detail::IntrusiveListImplementation m_Implementation;
 };
 
+template <class T, class Tag = T>
+class IntrusiveListBaseNode : public IntrusiveListNode {
+public:
+    IntrusiveListBaseNode();
+};
+
+template <class T, class Tag = T>
+class IntrusiveListBaseNodeTraits {
+public:
+    using BaseNodeType = IntrusiveListBaseNode<T, Tag>;
+
+    static IntrusiveListNode& GetNode(T& ref) { return ref; }
+
+    static const IntrusiveListNode& GetNode(const T& ref) { return ref; }
+
+    static T& GetItem(IntrusiveListNode& node) {
+        return static_cast<T&>(node);
+    }
+
+    static const T& GetItem(const IntrusiveListNode& node) {
+        return static_cast<const T&>(node);
+    }
+};
+
 template <class HolderT, IntrusiveListNode HolderT::*Member, class T = HolderT>
 class IntrusiveListMemberNodeTraits {
     friend class IntrusiveList<T, IntrusiveListMemberNodeTraits>;

--- a/include/nn/util/util_IntrusiveList.h
+++ b/include/nn/util/util_IntrusiveList.h
@@ -338,6 +338,26 @@ private:
     detail::IntrusiveListImplementation m_Implementation;
 };
 
+template <class T, class Tag = T>
+class IntrusiveListBaseNode : public IntrusiveListNode {
+public:
+    IntrusiveListBaseNode();
+};
+
+template <class T, class Tag = T>
+class IntrusiveListBaseNodeTraits {
+public:
+    using BaseNodeType = IntrusiveListBaseNode<T, Tag>;
+
+    static IntrusiveListNode& GetNode(T& ref) { return ref; }
+
+    static const IntrusiveListNode& GetNode(const T& ref) { return ref; }
+
+    static T& GetItem(IntrusiveListNode& node) { return static_cast<T&>(node); }
+
+    static const T& GetItem(const IntrusiveListNode& node) { return static_cast<const T&>(node); }
+};
+
 template <class HolderT, IntrusiveListNode HolderT::*Member, class T = HolderT>
 class IntrusiveListMemberNodeTraits {
     friend class IntrusiveList<T, IntrusiveListMemberNodeTraits>;


### PR DESCRIPTION
This PR just defines two classes, `nn::util::IntrusiveListBaseNode` and `nn::util::IntrusiveListBaseNodeTraits`, both of which are used in `atk`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/75)
<!-- Reviewable:end -->
