### PR TITLE
util: Add string utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ add_library(NintendoSDK OBJECT
   include/nn/util/util_IntrusiveList.h
   include/nn/util/util_BitUtil.h
   include/nn/util/util_ResDic.h
+  include/nn/util/util_StringUtil.h
   include/nn/util/util_StringView.h
   include/nn/ui2d/detail/TexCoordArray.h
   include/nn/ui2d/Layout.h

--- a/include/nn/util/util_StringUtil.h
+++ b/include/nn/util/util_StringUtil.h
@@ -1,0 +1,51 @@
+#include <nn/types.h>
+
+namespace nn::util {
+template <typename T>
+inline s32 Strlcpy(T* pOutDst, const T* pSrc, s32 count) {
+    s32 length = 0;
+
+    if (count > 0) {
+        while (--count && *pSrc) {
+            *pOutDst++ = *pSrc++;
+            ++length;
+        }
+        *pOutDst++ = '\0';
+    }
+
+    while (*pSrc++)
+        ++length;
+
+    return length;
+}
+
+template <typename T>
+inline s32 Strnlen(const T* pStr, s32 count) {
+    s32 length = 0;
+
+    if (count > 0) {
+        while (count && *pStr) {
+            ++pStr;
+            ++length;
+            --count;
+        }
+    }
+
+    return length;
+}
+
+template <typename T>
+inline s32 Strncmp(const T* pStr1, const T* pStr2, s32 count) {
+    if (count == 0)
+        return 0;
+
+    T c1, c2;
+
+    do {
+        c1 = *pStr1++;
+        c2 = *pStr2++;
+    } while (c1 && c1 == c2 && --count);
+
+    return c1 - c2;
+}
+}  // namespace nn::util


### PR DESCRIPTION
These are a bunch of functions I've found digging through DWARF info. In order to match, I decompiled a couple of functions that used them since all of them are inlined and are very much defined in the header. The games I checked with were Splatoon 2 (nw 1.6.0), SMO (nw 3.5.1) and Bloons TD 5 (nw 5.3.0).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/77)
<!-- Reviewable:end -->
