### PR TITLE
os: Implement `os::Mutex`

### DIFF
--- a/include/nn/os/os_Mutex.h
+++ b/include/nn/os/os_Mutex.h
@@ -5,8 +5,7 @@
 
 namespace nn::os {
 
-// todo: figure out where these go
-void InitializeMutex(MutexType*, bool, s32);
+void InitializeMutex(MutexType*, bool recursive, s32 lockLevel);
 void FinalizeMutex(MutexType*);
 void LockMutex(MutexType*);
 bool TryLockMutex(MutexType*);
@@ -20,20 +19,29 @@ class Mutex {
 public:
     explicit Mutex(bool recursive) { InitializeMutex(&m_Mutex, recursive, 0); }
 
-    Mutex(bool, int);
-    ~Mutex();
+    Mutex(bool recursive, s32 lockLevel) { InitializeMutex(&m_Mutex, recursive, lockLevel); };
+
+    ~Mutex() { FinalizeMutex(&m_Mutex); }
 
     void Lock() { LockMutex(&m_Mutex); }
 
-    bool TryLock();
+    bool TryLock() { return TryLockMutex(&m_Mutex); }
+
     void Unlock() { UnlockMutex(&m_Mutex); }
-    bool IsLockedByCurrentThread() const;
-    void lock();
-    bool try_lock();
-    void unlock();
-    operator MutexType&();
-    operator const MutexType&() const;
-    MutexType* GetBase();
+
+    bool IsLockedByCurrentThread() const { return IsMutexLockedByCurrentThread(&m_Mutex); };
+
+    void lock() { Lock(); }
+
+    bool try_lock() { return TryLock(); }
+
+    void unlock() { Unlock(); }
+
+    operator MutexType&() { return m_Mutex; }
+
+    operator const MutexType&() const { return m_Mutex; }
+
+    MutexType* GetBase() { return &m_Mutex; }
 
 private:
     MutexType m_Mutex;


### PR DESCRIPTION
This is mostly based on DWARF info and work I have done on `nn::atk`. There really doesn't seem to be more to these functions other than just calling the global Mutex functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/78)
<!-- Reviewable:end -->
