### PR TITLE
atk: Add SequenceSoundInfo definition to SoundArchive

### DIFF
--- a/include/nn/atk.h
+++ b/include/nn/atk.h
@@ -7,6 +7,8 @@ namespace atk {
 
 class SoundArchive {
 public:
+    struct SequenceSoundInfo;
+
     const char* GetItemLabel(u32 id) const;
     u32 GetItemId(const char* label) const;
 };


### PR DESCRIPTION
Simple change required for https://github.com/MonsterDruide1/OdysseyDecomp/pull/1345 to compile I didn't add the full header since that's done in #59

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/79)
<!-- Reviewable:end -->
