### PR TITLE
os: Implement `os::Event`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ add_library(NintendoSDK OBJECT
   include/nn/oe.h
   include/nn/util.h
   include/nn/image.h
+  include/nn/os/os_Event.h
+  include/nn/os/os_EventCommon.h
+  include/nn/os/os_EventTypes.h
   include/nn/util/AccessorBase.h
   include/nn/util/MathTypes.h
   include/nn/util/util_Arithmetic.h

--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -11,9 +11,9 @@
 #include <nn/types.h>
 
 #include <nn/os/detail/os_InternalCriticalSection.h>
+#include <nn/os/os_Event.h>
 #include <nn/os/os_MessageQueueTypes.h>
 #include <nn/os/os_Mutex.h>
-#include <nn/os/os_MutexTypes.h>
 #include <nn/os/os_ThreadTypes.h>
 
 namespace nn {
@@ -21,7 +21,6 @@ namespace os {
 
 namespace detail {
 
-class MultiWaitObjectList;
 struct InterProcessEventType {
     enum State {
         State_NotInitialized = 0,
@@ -48,22 +47,6 @@ struct Tick {
 struct LightEventType {
     std::aligned_storage_t<0xc, 4> storage;
 };
-
-struct EventType {
-    util::TypedStorage<detail::MultiWaitObjectList, 16, 8> _multiWaitObjectList;
-    bool _signalState;
-    bool _initiallySignaled;
-    uint8_t _clearMode;
-    uint8_t _state;
-    uint32_t _broadcastCounterLower;
-    uint32_t _broadcastCounterUpper;
-    detail::InternalCriticalSectionStorage _csEvent;
-    detail::InternalConditionVariableStorage _cvSignaled;
-};
-static_assert(std::is_trivial<EventType>::value, "EventType non trivial");
-typedef EventType Event;
-
-enum EventClearMode { EventClearMode_ManualClear, EventClearMode_AutoClear };
 
 struct ConditionVariableType {};
 
@@ -153,15 +136,6 @@ void ResumeThread(nn::os::ThreadType*);
 void SleepThread(nn::TimeSpan);
 void WaitThread(nn::os::ThreadType*);
 void SetThreadCoreMask(nn::os::ThreadType*, int, u64 mask);
-
-// EVENTS
-void InitializeEvent(EventType*, bool initiallySignaled, EventClearMode eventClearMode);
-void FinalizeEvent(EventType*);
-void SignalEvent(EventType*);
-void WaitEvent(EventType*);
-bool TryWaitEvent(EventType*);
-bool TimedWaitEvent(EventType*, nn::TimeSpan);
-void ClearEvent(EventType*);
 
 // LIGHT EVENTS
 void InitializeLightEvent(LightEventType*, bool initiallySignaled, EventClearMode eventClearMode);

--- a/include/nn/os/os_Event.h
+++ b/include/nn/os/os_Event.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <nn/os/os_EventCommon.h>
+#include <nn/os/os_EventTypes.h>
+#include <nn/time.h>
+#include <nn/util.h>
+
+namespace nn::os {
+
+void InitializeEvent(EventType*, bool initiallySignaled, EventClearMode eventClearMode);
+void FinalizeEvent(EventType*);
+void SignalEvent(EventType*);
+void WaitEvent(EventType*);
+bool TryWaitEvent(EventType*);
+bool TimedWaitEvent(EventType*, nn::TimeSpan);
+void ClearEvent(EventType*);
+
+class Event {
+    NN_NO_COPY(Event);
+    NN_NO_MOVE(Event);
+
+public:
+    explicit Event(EventClearMode clearMode) { InitializeEvent(&m_Event, false, clearMode); }
+
+    ~Event() { FinalizeEvent(&m_Event); }
+
+    void Wait() { WaitEvent(&m_Event); }
+
+    bool TryWait() { return TryWaitEvent(&m_Event); }
+
+    bool TimedWait(TimeSpan timeSpan) { return TimedWaitEvent(&m_Event, timeSpan); }
+
+    void Signal() { SignalEvent(&m_Event); }
+
+    void Clear() { ClearEvent(&m_Event); }
+
+    operator EventType&() { return m_Event; }
+
+    operator const EventType&() const { return m_Event; }
+
+    EventType* GetBase() { return &m_Event; }
+
+private:
+    EventType m_Event;
+};
+
+}  // namespace nn::os

--- a/include/nn/os/os_EventCommon.h
+++ b/include/nn/os/os_EventCommon.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace nn::os {
+enum EventClearMode { EventClearMode_ManualClear, EventClearMode_AutoClear };
+}  // namespace nn::os

--- a/include/nn/os/os_EventTypes.h
+++ b/include/nn/os/os_EventTypes.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <nn/os/detail/os_InternalConditionVariable.h>
+#include <nn/os/detail/os_InternalCriticalSection.h>
+#include <nn/util/util_TypedStorage.h>
+
+namespace nn::os {
+
+namespace detail {
+class MultiWaitObjectList;
+}  // namespace detail
+
+struct EventType {
+    util::TypedStorage<detail::MultiWaitObjectList, 16, 8> _multiWaitObjectList;
+    bool _signalState;
+    bool _initiallySignaled;
+    uint8_t _clearMode;
+    uint8_t _state;
+    uint32_t _broadcastCounterLower;
+    uint32_t _broadcastCounterUpper;
+    detail::InternalCriticalSectionStorage _csEvent;
+    detail::InternalConditionVariableStorage _cvSignaled;
+};
+static_assert(std::is_trivial<EventType>::value, "EventType non trivial");
+
+}  // namespace nn::os


### PR DESCRIPTION
The class itself is similar to `os::Mutex`, in that it's mostly a wrapper around global functions, so this follows a similar structure to https://github.com/open-ead/nnheaders/pull/78.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/80)
<!-- Reviewable:end -->
