### PR TITLE
os: fix ThreadType size for newer sdk versions

### DIFF
--- a/include/nn/os/os_ThreadTypes.h
+++ b/include/nn/os/os_ThreadTypes.h
@@ -38,7 +38,10 @@ struct ThreadType {
     ThreadFunction _threadFunction;
     FiberType* _currentFiber;
     FiberType* _initialFiber;
+    // may be inaccurate: SDK 4.4.0 and 5.4.150 has the field while 7.3.2 and 20.5.6 does not
+#if NN_SDK_VER < NN_MAKE_VER(6, 0, 0)
     uint32_t _lockHistory;
+#endif
     uintptr_t _tlsValueArray[32];
     char _threadNameBuffer[32];
     const char* _namePointer;
@@ -47,7 +50,11 @@ struct ThreadType {
     detail::InternalThreadHandle _handle;
 };
 #ifdef SWITCH
+#if NN_SDK_VER < NN_MAKE_VER(6, 0, 0)  // see _lockHistory above
 static_assert(sizeof(ThreadType) == 0x1C0, "Wrong size");
+#else
+static_assert(sizeof(ThreadType) == 0x1B8, "Wrong size");
+#endif
 #endif
 
 }  // namespace os


### PR DESCRIPTION
StartThread extracts the handle for syscall and the offset for handle was different -
inspected GetTlsValue and SwitchToFiber and narrowed down to this field

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/81)
<!-- Reviewable:end -->
