### PR TITLE
os: Fix compiler error about `NN_MAKE_VER` in `os_ThreadTypes.h`

### DIFF
--- a/include/nn/os/os_ThreadTypes.h
+++ b/include/nn/os/os_ThreadTypes.h
@@ -4,6 +4,7 @@
 #include <nn/os/detail/os_InternalCriticalSection.h>
 #include <nn/os/detail/os_ThreadTypes-os.horizon.h>
 #include <nn/os/os_ThreadCommon.h>
+#include <nn/util.h>
 #include <nn/util/util_TypedStorage.h>
 
 namespace nn {


### PR DESCRIPTION
Great example about the types of issues that the buildbot on this repo doesn't catch, but Odyssey's additional workflows do catch: A mistake in a standalone header.

Here, `NN_MAKE_VER` has been used, which must be included first. This error might be hidden when compiling entire classes, as the required file might be included by coincidence beforehand, or remains silent because this header is unused. In Odyssey, we have extra workflows that create "dummy classes" that use every header individually, and another one that just includes "everything", so mistakes like this and duplicate definitions can be caught as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/83)
<!-- Reviewable:end -->
