### PR TITLE
cmake: Fix NN_SDK_VER 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ function(nn_ver ID)
   list(POP_FRONT VER MAJOR MINOR PATCH)
   
   foreach(VAR IN ITEMS MAJOR MINOR PATCH)
-    target_compile_definitions(NintendoSDK PRIVATE ${ID}_${VAR}=${${VAR}})
+    target_compile_definitions(NintendoSDK PUBLIC ${ID}_${VAR}=${${VAR}})
   endforeach()
 endfunction()
 


### PR DESCRIPTION
I noticed that NN_SDK_VER is not defined with the correct value in #62 because the definitions aren't propagated correctly. 

My knowledge in cmake is near null but I was able to confirm that it works as it fixes all mismatches due wrong sdk version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-ead/nnheaders/84)
<!-- Reviewable:end -->
